### PR TITLE
[IOS-36] 

### DIFF
--- a/Project/App/Sources/Feature/Home/NotificationPermissionReducer.swift
+++ b/Project/App/Sources/Feature/Home/NotificationPermissionReducer.swift
@@ -1,0 +1,53 @@
+//
+//  NotificationPermissionReducer.swift
+//  ProductName
+//
+//  Created by 김유빈 on 6/17/25.
+//
+
+import UserNotifications
+
+import ComposableArchitecture
+
+@Reducer
+struct NotificationPermissionReducer {
+  @Dependency(\.userNotificationClient) var userNotificationClient
+
+  @ObservableState
+  struct State: Equatable {
+    var isNotificationAuthorized: Bool?
+  }
+
+  enum Action {
+    case allowButtonTapped
+    case authorizationResponse(Bool)
+    case authorizationFailed(Error)
+  }
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .allowButtonTapped:
+        return .run { send in
+          do {
+            let isNotificationAuthorized = try await userNotificationClient.requestAuthorization()
+
+            await send(.authorizationResponse(isNotificationAuthorized))
+          } catch {
+            await send(.authorizationFailed(error))
+          }
+        }
+
+      case .authorizationResponse(let isNotificationAuthorized):
+        state.isNotificationAuthorized = isNotificationAuthorized
+
+        return .none
+
+      case .authorizationFailed(let error):
+        print("Push Notification Authorization failed with error: \(error)")
+
+        return .none
+      }
+    }
+  }
+}

--- a/Project/App/Sources/Feature/Home/NotificationPermissionView.swift
+++ b/Project/App/Sources/Feature/Home/NotificationPermissionView.swift
@@ -1,0 +1,45 @@
+//
+//  NotificationPermissionView.swift
+//  ProductName
+//
+//  Created by 김유빈 on 6/17/25.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct NotificationPermissionView: View {
+  let store: StoreOf<NotificationPermissionReducer>
+
+  init(store: StoreOf<NotificationPermissionReducer>) {
+    self.store = store
+  }
+
+  var body: some View {
+    // TODO: [IOS-25] BottomSheet 컴포넌트 PR 머지되면 주석 해제하기
+//    DHCBottomSheetContent(
+//      configuration: BottomSheetConfiguration(
+//        title: "알림 설정을\n허용해주세요",
+//        description: "서비스를 원활히 진행하기 위해서\n알림설정이 꼭 필요해요",
+//        showCloseButton: true,
+//        interactiveDisabled: true,
+//        firstButton: .init(
+//          title: "알림 허용하기",
+//          action: {
+//            store.send(.allowButtonTapped)
+//          }
+//        )
+//      )
+//    )
+  }
+}
+
+#Preview {
+  NotificationPermissionView(
+    store: Store(
+      initialState: .init(),
+      reducer: NotificationPermissionReducer.init
+    )
+  )
+}

--- a/Project/App/Sources/Services/UserNotification/UserNotificationClient.swift
+++ b/Project/App/Sources/Services/UserNotification/UserNotificationClient.swift
@@ -1,0 +1,42 @@
+//
+//  UserNotificationClient.swift
+//  ProductName
+//
+//  Created by 김유빈 on 6/19/25.
+//
+
+import ComposableArchitecture
+
+@DependencyClient
+struct UserNotificationClient: Sendable {
+  var requestAuthorization: () async throws -> Bool
+}
+
+extension UserNotificationClient: DependencyKey {
+  static var liveValue: UserNotificationClient = {
+    @Dependency(\.userNotificationService) var userNotificationService
+
+    return UserNotificationClient(
+      requestAuthorization: {
+        let isNotificationAuthorized = try await userNotificationService.requestAuthorization()
+        
+        return isNotificationAuthorized
+      }
+    )
+  }()
+
+  static var previewValue: UserNotificationClient {
+    UserNotificationClient()
+  }
+
+  static var testValue: UserNotificationClient {
+    UserNotificationClient()
+  }
+}
+
+extension DependencyValues {
+  var userNotificationClient: UserNotificationClient {
+    get { self[UserNotificationClient.self] }
+    set { self[UserNotificationClient.self] = newValue }
+  }
+}

--- a/Project/App/Sources/Services/UserNotification/UserNotificationError.swift
+++ b/Project/App/Sources/Services/UserNotification/UserNotificationError.swift
@@ -1,0 +1,11 @@
+//
+//  UserNotificationError.swift
+//  ProductName
+//
+//  Created by 김유빈 on 6/19/25.
+//
+
+enum UserNotificationError: Error {
+  case authorizationDenied
+  case unknownError(Error)
+}

--- a/Project/App/Sources/Services/UserNotification/UserNotificationService.swift
+++ b/Project/App/Sources/Services/UserNotification/UserNotificationService.swift
@@ -1,0 +1,50 @@
+//
+//  UserNotificationService.swift
+//  ProductName
+//
+//  Created by 김유빈 on 6/19/25.
+//
+
+import UserNotifications
+
+import ComposableArchitecture
+
+@DependencyClient
+struct UserNotificationService: Sendable {
+  var requestAuthorization: () async throws -> Bool
+}
+
+extension UserNotificationService: DependencyKey {
+  static var liveValue = UserNotificationService(
+    requestAuthorization: {
+      let center = UNUserNotificationCenter.current()
+
+      do {
+        let isNotificationAuthorized = try await center.requestAuthorization(options: [.alert, .sound])
+
+        if !isNotificationAuthorized {
+          throw UserNotificationError.authorizationDenied
+        }
+
+        return isNotificationAuthorized
+      } catch {
+        throw UserNotificationError.unknownError(error)
+      }
+    }
+  )
+
+  static var previewValue: UserNotificationService {
+    UserNotificationService()
+  }
+
+  static var testValue: UserNotificationService {
+    UserNotificationService()
+  }
+}
+
+extension DependencyValues {
+  var userNotificationService: UserNotificationService {
+    get { self[UserNotificationService.self] }
+    set { self[UserNotificationService.self] = newValue }
+  }
+}


### PR DESCRIPTION
## 📌 배경

- 푸시 알림 권한 요청을 위해 Service, Client, Reducer, View 작업 진행했습니다.

## ✅ 수정 내역

- `UserNotificationService`
  - 실제 시스템 알림 권한 요청 함수 정의

- `UserNotificationClient`
  - 의존성 주입을 위한 TCA용 클라이언트 정의
- `UserNotificationError`
  - 알림 권한 요청 실패 시 사용할 에러 케이스 정의
- `NotificationPermissionReducer`, `NotificationPermissionView`
  - 알림 권한 요청을 실제로 사용하기 위한 Reducer 및 View
  - BottomSheet 컴포넌트 머지 이후 주석 해제 예정
 

## 📢 리뷰 노트

- 현재는 권한 허용 요청하는 뷰 작업이라 필요한 함수만 추가했습니다. 추후 필요한 함수가 생기면 추가하도록 할게요!
- BottomSheet 컴포넌트가 머지 되기 전이라, `NotificationPermissionView`는 주석 처리 해뒀습니다! 컴포넌트 머지되면 주석 해제할게요
- `NotificationPermissionReducer`라는 별도의 파일을 만들어서 작업했는데, 기존에 있는 `HomeReducer`에 작성해야 할까요 ..? 🧐

## 📸 스크린샷
<!-- 
 - 이미지 추가시 아래 주석의 내용을 복사하여 표에 입력하여 사용해요.
  <img src="{{ 이미지 URL을 입력해주세요 }}" width="250" />

 - 동영상 추가시 아래 주석의 내용을 복사하여 표에 입력하여 사용해요.
  <video src="{{ 동영상 URL을 입력해주세요 }}" width="250" muted autoplay />

 | ScreenShot |
 | ---------- |
 | <img src="https://example.com/image.jpg" width="250" /> |
-->

<img src="https://github.com/user-attachments/assets/b5a3b97d-7acc-49c7-99fb-002f9d1dcf9a" width="250" /> <img src="https://github.com/user-attachments/assets/ebf6dc7e-44e0-46a7-bffb-2b5f372e2a6d" width="250" />