### PR TITLE
IOS-40 사용 중인 써드파티 라이브러리들을 dynamic framework로 변경

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -8,7 +8,11 @@ let packageSettings = PackageSettings(
 	// Customize the product types for specific package product
 	// Default is .staticFramework
 	// productTypes: ["Alamofire": .framework,]
-  productTypes: [:]
+  productTypes: [
+    "Alamofire": .framework,
+    "ComposableArchitecture": .framework,
+    "SDWebImageSwiftUI": .framework,
+  ]
 )
 #endif
 


### PR DESCRIPTION
## 📌 배경
- SwiftUI 프리뷰 빌드 실패

## ✅ 수정 내역

- 라이브러리들을 동적 프레임워크로 변경


## 📢 리뷰 노트

- 생략해요.