### PR TITLE
IOS-48 앱 초기화 알럿 UI를 구현해요.

### DIFF
--- a/Project/App/Sources/Feature/MyPage/Components/AppResetAlertView.swift
+++ b/Project/App/Sources/Feature/MyPage/Components/AppResetAlertView.swift
@@ -1,0 +1,119 @@
+//
+//  AppResetAlertView.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/28/25.
+//
+
+import SwiftUI
+
+struct AppResetAlertView: View {
+  let onReset: () -> Void
+  let onCancel: () -> Void
+
+  var body: some View {
+    ZStack {
+      ColorResource.Background.main.color.opacity(0.8)
+        .ignoresSafeArea()
+
+      VStack(spacing: 12) {
+        HStack {
+          Button(action: onCancel) {
+            Image(ImageResource.Icon.cancel)
+              .foregroundColor(.gray)
+          }
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+
+        VStack(spacing: 16) {
+          RoundedRectangle(cornerRadius: 12)
+            .fill(ColorResource.Neutral._500.color)
+            .frame(width: 280, height: 100)
+            .overlay(
+              Text("그래픽 들어갈 자리")
+                .foregroundColor(.white)
+            )
+
+          VStack(spacing: 4) {
+            Text("정말 앱을 초기화 하시겠어요?")
+              .textStyle(.h3)
+              .foregroundColor(ColorResource.Text.Body.primary.color)
+
+            Text("앱을 초기화하면 다시 복구할 수 없어요")
+              .textStyle(.body3)
+              .foregroundColor(ColorResource.Neutral._300.color)
+          }
+          .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 20)
+
+        VStack(spacing: 4) {
+          CTAButton(
+            size: .large,
+            style: .primary,
+            title: "이전으로 돌아가기",
+            action: onCancel
+          )
+
+          CTAButton(
+            size: .large,
+            style: .tertiary,
+            title: "초기화",
+            action: onReset
+          )
+        }
+        .padding(.horizontal, 20)
+      }
+      .padding(.vertical, 16)
+      .background(ColorResource.Neutral._700.color)
+      .cornerRadius(12)
+      .padding(.horizontal, 32)
+    }
+  }
+}
+
+// MARK: - Reset Alert Modifier
+
+struct AppResetAlertModifier: ViewModifier {
+  @Binding var isPresented: Bool
+  let onReset: () -> Void
+  let onCancel: () -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .fullScreenCover(isPresented: $isPresented) {
+        AppResetAlertView(
+          onReset: onReset,
+          onCancel: onCancel
+        )
+        .presentationBackground(.clear)
+      }
+      .transaction { transaction in
+        transaction.disablesAnimations = true
+      }
+  }
+}
+
+extension View {
+  func resetAlert(
+    isPresented: Binding<Bool>,
+    onReset: @escaping () -> Void,
+    onCancel: @escaping () -> Void = {}
+  ) -> some View {
+    modifier(
+      AppResetAlertModifier(
+        isPresented: isPresented,
+        onReset: onReset,
+        onCancel: onCancel
+      )
+    )
+  }
+}
+
+#Preview {
+  AppResetAlertView(
+    onReset: { print("Reset tapped") },
+    onCancel: { print("Cancel tapped") }
+  )
+}

--- a/Project/App/Sources/Feature/MyPage/MyPageView.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageView.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 
 struct MyPageView: View {
   @Bindable var store: StoreOf<MyPageReducer>
+  @State private var showResetAlert = false
 
   var body: some View {
     ScrollView {
@@ -71,20 +72,10 @@ struct MyPageView: View {
               title: "앱 초기화",
               iconName: "icon/signOut",
               action: {
-                print("앱 초기화 버튼 클릭")
+                showResetAlert = true
               }
             )
-
-            Divider()
-              .background(ColorResource.Background.glassEffect.color)
-
-            SettingListRowView(
-              title: "알림 설정",
-              iconName: "icon/signOut",
-              toggleValue: .constant(true)
-            )
           }
-          .padding(.vertical, 12)
           .padding(.horizontal, 16)
           .frame(maxWidth: .infinity)
           .background(ColorResource.Neutral._700.color)
@@ -94,5 +85,17 @@ struct MyPageView: View {
         .padding(.horizontal, 20)
       }
     }
+    .resetAlert(
+      isPresented: $showResetAlert,
+      onReset: {
+        // TODO: 실제 초기화 로직 구현
+        print("앱 초기화 실행")
+        showResetAlert = false
+      },
+      onCancel: {
+        print("초기화 취소")
+        showResetAlert = false
+      }
+    )
   }
 }


### PR DESCRIPTION
## 📌 배경
- 마이페이지에 필요한 앱 초기화 알럿 UI를 구현해요.

## ✅ 수정 내역

- AppResetAlertView 구현
- 모디파이어 구현


## 📢 리뷰 노트

- 일단 바닐라 스유의 present 상태로 뜨도록 했는데 나중에 TCA의 Tree-based Navigation으로 변경할 수 있어요.

## 📸 스크린샷

 | ScreenShot |
 | ---------- |
 | <video src="https://github.com/user-attachments/assets/4f4a0327-607b-4916-b580-9f4b797d9083" width="250" muted autoplay /> |







