### PR TITLE
IOS-49 NetworkRequestInterceptor를 구현해요.

### DIFF
--- a/Project/App/Sources/Network/NetworkManager.swift
+++ b/Project/App/Sources/Network/NetworkManager.swift
@@ -14,7 +14,8 @@ protocol NetworkRequestable {
 }
 
 final class NetworkManager: NetworkRequestable {
-  private  let responseSerializer = DHCResponseSerializer()
+  private let responseSerializer = DHCResponseSerializer()
+  private let interceptor = NetworkRequestInterceptor()
 
   func request(_ target: RequestTarget) async throws -> DHCNetworkResponse {
     let request: URLRequest
@@ -24,7 +25,7 @@ final class NetworkManager: NetworkRequestable {
       throw NetworkManagerError.invalidURL
     }
 
-    let response = await AF.request(request)
+    let response = await AF.request(request, interceptor: interceptor)
       .validate()
       .serializingResponse(using: responseSerializer)
       .response

--- a/Project/App/Sources/Network/NetworkManagerError.swift
+++ b/Project/App/Sources/Network/NetworkManagerError.swift
@@ -10,5 +10,6 @@ enum NetworkManagerError: Error {
   case requestFailed(underlying: Error)
   case decodingFailed(underlying: Error)
   case emptyResponse
+  case userIDNotFound
   case unknown
 }

--- a/Project/App/Sources/Network/NetworkRequestInterceptor.swift
+++ b/Project/App/Sources/Network/NetworkRequestInterceptor.swift
@@ -1,0 +1,56 @@
+//
+//  NetworkRequestInterceptor.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/28/25.
+//
+
+import Foundation
+
+import Alamofire
+import ComposableArchitecture
+
+struct NetworkRequestInterceptor: RequestInterceptor {
+  @Dependency(\.userManager) var userManager
+
+  func adapt(
+    _ urlRequest: URLRequest,
+    for session: Session,
+    completion: @escaping (Result<URLRequest, any Error>) -> Void
+  ) {
+    var modifiedRequest = urlRequest
+
+    // URL이 존재하는지 확인
+    guard let url = urlRequest.url else {
+      completion(.success(urlRequest))
+      return
+    }
+
+    let path = url.path
+
+    // {userID} 패턴이 포함된 경우 실제 userID로 교체
+    if path.contains("{userID}") {
+      guard let actualUserID = userManager.getUserID() else {
+        // userID가 없는 경우 에러 반환
+        completion(.failure(NetworkManagerError.userIDNotFound))
+        return
+      }
+
+      guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+        completion(.failure(NetworkManagerError.invalidURL))
+        return
+      }
+
+      // {userID}를 실제 userID로 교체
+      urlComponents.path = path.replacingOccurrences(of: "{userID}", with: actualUserID)
+
+      // 새로운 URL 생성
+      let newURL = urlComponents.url
+
+      // 수정된 URL로 URLRequest 업데이트
+      modifiedRequest.url = newURL
+    }
+
+    completion(.success(modifiedRequest))
+  }
+}

--- a/Project/App/Sources/Util/UserID/UserManager.swift
+++ b/Project/App/Sources/Util/UserID/UserManager.swift
@@ -1,0 +1,54 @@
+//
+//  UserManager.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/28/25.
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+@DependencyClient
+struct UserManager {
+  var getUserID: () -> String?
+  var setUserID: (String) -> Void
+  var deleteUserID: () -> Void
+}
+
+extension UserManager: DependencyKey {
+  static var liveValue: UserManager = {
+    @ObservationIgnored
+    @Shared(.appStorage("userID")) var userID: String?
+    return UserManager(
+      getUserID: {
+        userID
+      },
+      setUserID: { newID in
+        $userID.withLock { userID in
+          userID = newID
+        }
+      },
+      deleteUserID: {
+        $userID.withLock { userID in
+          userID = nil
+        }
+      }
+    )
+  }()
+
+  static let previewValue = UserManager(
+    getUserID: { "previewUserID" },
+    setUserID: { _ in },
+    deleteUserID: {}
+  )
+
+  static let testValue = Self()
+}
+
+extension DependencyValues {
+  var userManager: UserManager {
+    get { self[UserManager.self] }
+    set { self[UserManager.self] = newValue }
+  }
+}


### PR DESCRIPTION
## 📌 배경
- API 통신 시에 userID를 자동으로 넣기 위해 작업했어요.

## ✅ 수정 내역
- 원래는 토큰 기반으로 통신하면 헤더에 넣는 것이 일반적이지만 현재 서버 스펙상 userID는 인증 정보가 아니라 mvp 기간에는 path에 넣어달라고 해요.
- 그래서 interceptor를 만들지 말까 하다가 api 선언할 때 마다 userID 가져오는 것이 비효율적일 것 같아서 추가했어요.
- Request를 인터셉팅해서 {userID}로 기입된 path를 실제 userID로 교체하는 방식이에요.

**사용법**
``` swift
enum UserAPI: RequestTarget {
  case home

  var path: String {
    switch self {
    case .home:
      "view/users/{userID}/home"  // <= 실제 통신에서는 자동으로 실제 userID로 replace 돼요.
    }
  }

  var method: HTTPMethod {
    switch self {
    case .home:
      .get
    }
  }
  // 생략
}
```

## 📢 리뷰 노트

- 로직 검증은 아직 안 해봐서 나중에 서버 통신 작업할 때 잘 되는지 간접 테스트 부탁드려요~