### PR TITLE
IOS-53 2,3 탭의 네비게이션 바 구성

### DIFF
--- a/Project/App/Sources/Design System/View/NavigationBar/LargeNavigationTitleView.swift
+++ b/Project/App/Sources/Design System/View/NavigationBar/LargeNavigationTitleView.swift
@@ -1,0 +1,25 @@
+//
+//  LargeNavigationTitleView.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/29/25.
+//
+
+import SwiftUI
+
+struct LargeNavigationTitleView: View {
+  let title: String
+
+  var body: some View {
+    Text(title)
+      .textStyle(.h2_1)
+      .foregroundStyle(ColorResource.Text.Body.primary.color)
+      .padding(.horizontal, 20)
+      .padding(.vertical, 12)
+      .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+#Preview {
+  LargeNavigationTitleView(title: "마이페이지")
+}

--- a/Project/App/Sources/Feature/MainTab/MainTabView.swift
+++ b/Project/App/Sources/Feature/MainTab/MainTabView.swift
@@ -40,7 +40,6 @@ struct MainTabView: View {
               action: \.missionStatusTab
             )
           )
-          .navigationTitle(Text("통계"))
         }
       } label: {
         Image(.Icon.status)
@@ -56,7 +55,6 @@ struct MainTabView: View {
               action: \.myPageTab
             )
           )
-          .navigationTitle(Text("마이페이지"))
         }
       } label: {
         Image(.Icon.mypage)

--- a/Project/App/Sources/Feature/MissionStatus/MissionStatusView.swift
+++ b/Project/App/Sources/Feature/MissionStatus/MissionStatusView.swift
@@ -85,5 +85,10 @@ struct MissionStatusView: View {
         .padding(.bottom, 20)
       }
     }
+    .radialGradientBackground(
+      type: .backgroundGradient02,
+      endRadiusMultiplier: 1.2,
+      scaleEffectX: 1.8
+    )
   }
 }

--- a/Project/App/Sources/Feature/MissionStatus/MissionStatusView.swift
+++ b/Project/App/Sources/Feature/MissionStatus/MissionStatusView.swift
@@ -85,6 +85,7 @@ struct MissionStatusView: View {
         .padding(.bottom, 20)
       }
     }
+    .contentMargins(.bottom, 46)
     .radialGradientBackground(
       type: .backgroundGradient02,
       endRadiusMultiplier: 1.2,

--- a/Project/App/Sources/Feature/MissionStatus/MissionStatusView.swift
+++ b/Project/App/Sources/Feature/MissionStatus/MissionStatusView.swift
@@ -30,6 +30,8 @@ struct MissionStatusView: View {
 
   var body: some View {
     ScrollView {
+      LargeNavigationTitleView(title: "통계")
+
       VStack(spacing: 0) {
         VStack(alignment: .leading, spacing: 12) {
           Text("소비 분석")

--- a/Project/App/Sources/Feature/MyPage/MyPageView.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageView.swift
@@ -15,6 +15,8 @@ struct MyPageView: View {
 
   var body: some View {
     ScrollView {
+      LargeNavigationTitleView(title: "마이페이지")
+
       VStack(spacing: 0) {
         // 내 사주 정보
         VStack(spacing: 16) {


### PR DESCRIPTION
## 📌 배경
- 미션 현황, 마이페이지 뷰에 쓰이는 네비게이션 타이틀 뷰 구현

## ✅ 수정 내역

- 자잘한 UI 개선
- 그라데이션 적용


## 📢 리뷰 노트

- 생략해요.

## 📸 스크린샷 

 | ScreenShot |
 | ---------- |
 | <video src="https://github.com/user-attachments/assets/1880eac0-0f78-4de7-a85d-3f26c1a6659c" width="250" muted autoplay /> |




