### PR TITLE
IOS-52 탈퇴 로직을 구현해요.

### DIFF
--- a/Project/App/Sources/App/RootReducer.swift
+++ b/Project/App/Sources/App/RootReducer.swift
@@ -34,6 +34,10 @@ struct RootReducer {
         state.destination = .mainTab(MainTabReducer.State())
         return .none
 
+      case .destination(.presented(.mainTab(.myPageTab(.delegate(.moveToOnboarding))))):
+        state.destination = .onboarding(OnboardingReducer.State())
+        return .none
+
       case .destination:
         return .none
 

--- a/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertReducer.swift
+++ b/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertReducer.swift
@@ -1,0 +1,40 @@
+//
+//  AppResetAlertReducer.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/29/25.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct AppResetAlertReducer {
+  init() {}
+
+  @ObservableState
+  struct State: Equatable {
+  }
+
+  enum Action {
+    // View Action
+    case confirmButtonTapped
+    case cancelButtonTapped
+
+    // Internal Action
+
+    // Route Action
+  }
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .confirmButtonTapped:
+        print("초기화 버튼 탭")
+        return .none
+      case .cancelButtonTapped:
+        print("취소 버튼 탭")
+        return .none
+      }
+    }
+  }
+}

--- a/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertView.swift
+++ b/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertView.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 struct AppResetAlertView: View {
-  let onReset: () -> Void
-  let onCancel: () -> Void
+  @Bindable var store: StoreOf<AppResetAlertReducer>
 
   var body: some View {
     ZStack {
@@ -17,7 +18,9 @@ struct AppResetAlertView: View {
         .ignoresSafeArea()
 
       VStack(spacing: 12) {
-        Button(action: onCancel) {
+        Button {
+          store.send(.cancelButtonTapped)
+        } label: {
           Image(ImageResource.Icon.cancel)
             .resizable()
             .frame(width: 28, height: 28)
@@ -54,14 +57,14 @@ struct AppResetAlertView: View {
             size: .large,
             style: .primary,
             title: "이전으로 돌아가기",
-            action: onCancel
+            action: { store.send(.cancelButtonTapped) }
           )
 
           CTAButton(
             size: .large,
             style: .tertiary,
             title: "초기화",
-            action: onReset
+            action: { store.send(.confirmButtonTapped) }
           )
         }
         .padding(.horizontal, 20)
@@ -77,18 +80,13 @@ struct AppResetAlertView: View {
 // MARK: - Reset Alert Modifier
 
 struct AppResetAlertModifier: ViewModifier {
-  @Binding var isPresented: Bool
-  let onReset: () -> Void
-  let onCancel: () -> Void
+  let item: Binding<StoreOf<AppResetAlertReducer>?>
 
   func body(content: Content) -> some View {
     content
-      .fullScreenCover(isPresented: $isPresented) {
-        AppResetAlertView(
-          onReset: onReset,
-          onCancel: onCancel
-        )
-        .presentationBackground(.clear)
+      .fullScreenCover(item: item) { store in
+        AppResetAlertView(store: store)
+          .presentationBackground(.clear)
       }
       .transaction { transaction in
         transaction.disablesAnimations = true
@@ -98,23 +96,17 @@ struct AppResetAlertModifier: ViewModifier {
 
 extension View {
   func resetAlert(
-    isPresented: Binding<Bool>,
-    onReset: @escaping () -> Void,
-    onCancel: @escaping () -> Void = {}
+    item: Binding<StoreOf<AppResetAlertReducer>?>
   ) -> some View {
-    modifier(
-      AppResetAlertModifier(
-        isPresented: isPresented,
-        onReset: onReset,
-        onCancel: onCancel
-      )
-    )
+    modifier(AppResetAlertModifier(item: item))
   }
 }
 
 #Preview {
   AppResetAlertView(
-    onReset: { print("Reset tapped") },
-    onCancel: { print("Cancel tapped") }
+    store: .init(
+      initialState: AppResetAlertReducer.State(),
+      reducer: AppResetAlertReducer.init
+    )
   )
 }

--- a/Project/App/Sources/Feature/MyPage/MyPageReducer.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageReducer.swift
@@ -34,6 +34,10 @@ struct MyPageReducer {
 
     /// Navigation Actions
     case appResetAlert(PresentationAction<AppResetAlertReducer.Action>)
+    case delegate(Delegate)
+    enum Delegate {
+      case moveToOnboarding
+    }
   }
 
   var body: some ReducerOf<Self> {
@@ -73,7 +77,18 @@ struct MyPageReducer {
         state.appResetAlert = .init()
         return .none
 
+      case .appResetAlert(.presented(.delegate(.cancel))):
+        state.appResetAlert = nil
+        return .none
+
+      case .appResetAlert(.presented(.delegate(.resetCompleted))):
+        state.appResetAlert = nil
+        return .send(.delegate(.moveToOnboarding))
+
       case .appResetAlert:
+        return .none
+
+      case .delegate:
         return .none
       }
     }

--- a/Project/App/Sources/Feature/MyPage/MyPageReducer.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageReducer.swift
@@ -19,6 +19,7 @@ struct MyPageReducer {
     var myPageInfo: MyPageInfo
     var isLoading = false
     var isRedacted = false
+    @Presents var appResetAlert: AppResetAlertReducer.State?
   }
 
   enum Action {
@@ -32,7 +33,7 @@ struct MyPageReducer {
     case myPageDataFailed(Error)
 
     /// Navigation Actions
-    case resetAppConfirmed
+    case appResetAlert(PresentationAction<AppResetAlertReducer.Action>)
   }
 
   var body: some ReducerOf<Self> {
@@ -69,13 +70,15 @@ struct MyPageReducer {
         return .none
 
       case .resetAppButtonTapped:
-        return .none // Alert 표시는 현재 View에서 처리
+        state.appResetAlert = .init()
+        return .none
 
-      case .resetAppConfirmed:
-        // TODO: 실제 앱 초기화 로직 구현
-        // UserDefaults 클리어, Keychain 클리어 등
+      case .appResetAlert:
         return .none
       }
+    }
+    .ifLet(\.$appResetAlert, action: \.appResetAlert) {
+      AppResetAlertReducer()
     }
   }
 

--- a/Project/App/Sources/Feature/MyPage/MyPageView.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageView.swift
@@ -15,6 +15,7 @@ struct MyPageView: View {
   var body: some View {
     ScrollView {
       LargeNavigationTitleView(title: "마이페이지")
+        .unredacted()
 
       VStack(spacing: 0) {
         // 내 사주 정보

--- a/Project/App/Sources/Feature/MyPage/MyPageView.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageView.swift
@@ -11,7 +11,6 @@ import ComposableArchitecture
 
 struct MyPageView: View {
   @Bindable var store: StoreOf<MyPageReducer>
-  @State private var showResetAlert = false
 
   var body: some View {
     ScrollView {
@@ -74,7 +73,7 @@ struct MyPageView: View {
               title: "앱 초기화",
               iconName: "icon/signOut",
               action: {
-                showResetAlert = true
+                store.send(.resetAppButtonTapped)
               }
             )
           }
@@ -92,14 +91,7 @@ struct MyPageView: View {
     }
     .redacted(reason: store.isRedacted ? .placeholder : [])
     .resetAlert(
-      isPresented: $showResetAlert,
-      onReset: {
-        store.send(.resetAppConfirmed)
-        showResetAlert = false
-      },
-      onCancel: {
-        showResetAlert = false
-      }
+      item: $store.scope(state: \.appResetAlert, action: \.appResetAlert)
     )
   }
 }

--- a/Project/App/Sources/Services/MyPageService/MyPageAPI.swift
+++ b/Project/App/Sources/Services/MyPageService/MyPageAPI.swift
@@ -11,6 +11,7 @@ import Alamofire
 
 enum MyPageAPI {
   case myPage
+  case resetApp
 }
 
 extension MyPageAPI: RequestTarget {
@@ -18,6 +19,8 @@ extension MyPageAPI: RequestTarget {
     switch self {
     case .myPage:
       "/view/users/{userID}/myPage"
+    case .resetApp:
+      "/api/users/{userID}"
     }
   }
 
@@ -25,19 +28,21 @@ extension MyPageAPI: RequestTarget {
     switch self {
     case .myPage:
       .get
+    case .resetApp:
+      .delete
     }
   }
 
   var queryParameters: Parameters? {
     switch self {
-    case .myPage:
+    case .myPage, .resetApp:
       nil
     }
   }
 
   var bodyParameters: Parameters? {
     switch self {
-    case .myPage:
+    case .myPage, .resetApp:
       nil
     }
   }

--- a/Project/App/Sources/Services/MyPageService/MyPageClient.swift
+++ b/Project/App/Sources/Services/MyPageService/MyPageClient.swift
@@ -12,24 +12,30 @@ import ComposableArchitecture
 @DependencyClient
 struct MyPageClient {
   var fetchMyPageInfo: () async throws -> MyPageInfo
+  var resetApp: () async throws -> Void
 }
 
 extension MyPageClient: DependencyKey {
   static let liveValue: Self = {
     let networkManager = NetworkManager()
 
-    return MyPageClient(fetchMyPageInfo: {
-      try await networkManager
-        .request(MyPageAPI.myPage)
-        .map(to: MyPageDTO.self)
-        .toDomain()
-    })
+    return MyPageClient(
+      fetchMyPageInfo: {
+        try await networkManager
+          .request(MyPageAPI.myPage)
+          .map(to: MyPageDTO.self)
+          .toDomain()
+      },
+      resetApp: {
+        _ = try await networkManager
+          .request(MyPageAPI.resetApp)
+      }
+    )
   }()
 
   static let previewValue = MyPageClient(
-    fetchMyPageInfo: {
-      .sample
-    }
+    fetchMyPageInfo: { .sample },
+    resetApp: {}
   )
   static let testValue = Self()
 }


### PR DESCRIPTION
## 📌 배경
- 탈퇴 로직 구현

## ✅ 수정 내역

- 앱 탈퇴 로직을 담당하는 AppResetAlertReducer를 생성했어요.
- TCA의 Tree-based Navigation을 사용하여 알럿을 present해요.
- 탈퇴 로직을 수행하고 온보딩 화면으로 라우팅시켜요.
  - 부모 리듀서에서 처리가 필요한 액션들은 Delegate 액션으로 선언했어요.

## 📢 리뷰 노트

- 생략해요.

## 📸 스크린샷
 | ScreenShot |
 | ---------- |
 | <video src="https://github.com/user-attachments/assets/73662229-09b2-4511-a2fe-962120132f36" width="250" muted autoplay /> |






