### PR TITLE
IOS-54 로딩 스피너를 추가해요.

### DIFF
--- a/Project/App/Resources/Color.xcassets/Etc/#2D2D2D.colorset/Contents.json
+++ b/Project/App/Resources/Color.xcassets/Etc/#2D2D2D.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2D",
+          "green" : "0x2D",
+          "red" : "0x2D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Project/App/Sources/Design System/View/Loading/DHCLoadingSpinner.swift
+++ b/Project/App/Sources/Design System/View/Loading/DHCLoadingSpinner.swift
@@ -1,0 +1,70 @@
+//
+//  DHCLoadingSpinner.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/29/25.
+//
+
+import SwiftUI
+
+struct DHCLoadingSpinner: View {
+  @State private var isAnimating = false
+  private let size: CGFloat = 40
+  private let strokeWidth: CGFloat = 8
+  private let gradient = AngularGradient(
+    gradient: Gradient(colors: [ColorResource._2_D_2_D_2_D.color, .white]),
+    center: .center,
+    startAngle: .degrees(.zero),
+    endAngle: .degrees(360)
+  )
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(
+          gradient,
+          style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+        )
+        .frame(width: size, height: size)
+        .rotationEffect(.degrees(isAnimating ? 360 : 0))
+        .animation(
+          .linear(duration: 1)
+            .repeatForever(autoreverses: false),
+          value: isAnimating
+        )
+    }
+    .onAppear {
+      startAnimation()
+    }
+  }
+
+  private func startAnimation() {
+    withAnimation {
+      isAnimating = true
+    }
+  }
+}
+
+// MARK: - 로딩 오버레이 뷰
+
+struct DHCLoadingOverlay: View {
+
+  let needsDimming: Bool
+
+  var body: some View {
+    ZStack {
+      if needsDimming {
+        ColorResource.Background.main.color.opacity(0.8)
+          .ignoresSafeArea()
+      }
+
+      DHCLoadingSpinner()
+    }
+  }
+}
+
+#Preview("Loading Spinner") {
+  VStack(spacing: 40) {
+    DHCLoadingOverlay(needsDimming: true)
+  }
+}

--- a/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertReducer.swift
+++ b/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertReducer.swift
@@ -17,6 +17,7 @@ struct AppResetAlertReducer {
 
   @ObservableState
   struct State: Equatable {
+    var isLoading = false
   }
 
   enum Action {
@@ -36,6 +37,7 @@ struct AppResetAlertReducer {
     Reduce { state, action in
       switch action {
       case .confirmButtonTapped:
+        state.isLoading = true
         return .run { send in
           try await myPageClient.resetApp()
           userManager.deleteUserID()
@@ -45,6 +47,7 @@ struct AppResetAlertReducer {
       case .cancelButtonTapped:
         return .send(.delegate(.cancel))
       case .delegate:
+        state.isLoading = false
         return .none
       }
     }

--- a/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertView.swift
+++ b/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertView.swift
@@ -73,6 +73,7 @@ struct AppResetAlertView: View {
       .background(ColorResource.Neutral._700.color)
       .clipShape(.rect(cornerRadius: 12))
       .padding(.horizontal, 32)
+      .loadingOverlay(isLoading: store.isLoading)
     }
   }
 }

--- a/Project/App/Sources/Util/Extension/SwiftUI+/View+Loading.swift
+++ b/Project/App/Sources/Util/Extension/SwiftUI+/View+Loading.swift
@@ -1,0 +1,27 @@
+//
+//  View+Loading.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 6/29/25.
+//
+
+import SwiftUI
+
+extension View {
+  /// 로딩 오버레이를 표시합니다.
+  ///
+  /// - Parameters:
+  ///   - isLoading: 로딩 상태
+  /// - Returns: 로딩 오버레이가 적용된 뷰
+  func loadingOverlay(
+    isLoading: Bool,
+    needsDimming: Bool = true
+  ) -> some View {
+    self
+      .overlay {
+        if isLoading {
+          DHCLoadingOverlay(needsDimming: needsDimming)
+        }
+      }
+  }
+}


### PR DESCRIPTION
## 📌 배경
- API 통신 시 스피너가 필요한 케이스 대응을 위해 디자인 시스템에 스피너를 추가해요.
- [피그마](https://www.figma.com/design/q3qSDq2h9dO1p56Hb5tky0/Design-%F0%9F%9A%97---DHC?node-id=573-20155&t=E6iOm1yqZVDYZOWN-11)
- 피그마 댓글에서는 디자이너분들이 로띠로 준다고 되어 있는데 재미삼아 커서한테 맡기니까 잘 만들어줘서 조금만 손 봤어요.
- 이거 사용하다가 이후에 로띠 결과물이 현재 스피너랑 유사하다면 구현한 스피너를 사용하는 것이 더 가벼울 것 같긴해요.

## ✅ 수정 내역

- 스피너 추가, 로딩 스피너를 편하게 쓰기 위한 모디파이어 추가
- 앱 초기화 버튼 누르면 초기화 로직 완료전까지 로딩 스피너 보여주기


## 📢 리뷰 노트

- 생략해요.

## 📸 스크린샷
 | 사용 예시 |
 | ---------- |
 | <video src="https://github.com/user-attachments/assets/62920e0d-4be7-4a05-958a-42b645b9afac" width="250" muted autoplay /> |






