### PR TITLE
IOS-45 홈화면에 필요한 컴포넌트 작업과 홈화면을 구성해요

### DIFF
--- a/Project/App/Resources/Color.xcassets/Etc/#5194FF.colorset/Contents.json
+++ b/Project/App/Resources/Color.xcassets/Etc/#5194FF.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x94",
+          "red" : "0x51"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x94",
+          "red" : "0x51"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Project/App/Resources/Color.xcassets/Etc/#6F6F6F.colorset/Contents.json
+++ b/Project/App/Resources/Color.xcassets/Etc/#6F6F6F.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6F",
+          "green" : "0x6F",
+          "red" : "0x6F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6F",
+          "green" : "0x6F",
+          "red" : "0x6F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Project/App/Resources/Color.xcassets/Etc/#E9FBFF.colorset/Contents.json
+++ b/Project/App/Resources/Color.xcassets/Etc/#E9FBFF.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFB",
+          "red" : "0xE9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFB",
+          "red" : "0xE9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Project/App/Resources/Color.xcassets/Etc/#EEEBD8.colorset/Contents.json
+++ b/Project/App/Resources/Color.xcassets/Etc/#EEEBD8.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xEB",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xEB",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Project/App/Sources/Design System/View/Fortune/FortuneCoreView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneCoreView.swift
@@ -9,36 +9,40 @@ import SwiftUI
 
 struct FortuneCoreView: View {
   let score: Int
+  let action: () -> Void
+
   private var fortuneScore: FortuneScore {
     FortuneScore(score: score)
   }
 
   var body: some View {
-    VStack(spacing: 0) {
-      Text("금전운")
-        .textStyle(.body6)
-        .foregroundStyle(ColorResource.Neutral._300.color)
+    Button(action: action) {
+      VStack(spacing: 0) {
+        Text("금전운")
+          .textStyle(.body6)
+          .foregroundStyle(ColorResource.Neutral._300.color)
 
-      Text("\(score)점")
-        .textStyle(.h3)
-        .foregroundStyle(fortuneScore.textGradient)
-    }
-    .padding(20)
-    .background {
-      Circle()
-        .fill(
-          LinearGradient(.fortuneFill)
-            .opacity(0.15)
-        )
-        .frame(width: 80, height: 80)
-        .overlay(
-          Circle()
-            .stroke(
-              fortuneScore.strokeGradient
-                .opacity(0.28),
-              lineWidth: 1
-            )
-        )
+        Text("\(score)점")
+          .textStyle(.h3)
+          .foregroundStyle(fortuneScore.textGradient)
+      }
+      .padding(20)
+      .background {
+        Circle()
+          .fill(
+            LinearGradient(.fortuneFill)
+              .opacity(0.15)
+          )
+          .frame(width: 80, height: 80)
+          .overlay(
+            Circle()
+              .stroke(
+                fortuneScore.strokeGradient
+                  .opacity(0.28),
+                lineWidth: 1
+              )
+          )
+      }
     }
   }
 }
@@ -85,7 +89,7 @@ extension FortuneCoreView {
 }
 
 #Preview {
-  FortuneCoreView(score: 35)
-  FortuneCoreView(score: 60)
-  FortuneCoreView(score: 100)
+  FortuneCoreView(score: 35) {}
+  FortuneCoreView(score: 60) {}
+  FortuneCoreView(score: 100) {}
 }

--- a/Project/App/Sources/Design System/View/Fortune/FortuneCoreView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneCoreView.swift
@@ -1,0 +1,90 @@
+//
+//  FortuneCoreView.swift
+//  Flifin
+//
+//  Created by 김유빈 on 6/28/25.
+//
+
+import SwiftUI
+
+struct FortuneCoreView: View {
+  let score: Int
+
+  var body: some View {
+    let fortuneScore = FortuneScore(score: score)
+
+    VStack(spacing: 0) {
+      Text("금전운")
+        .textStyle(.body6)
+        .foregroundStyle(ColorResource.Neutral._300.color)
+
+      Text("\(score)점")
+        .textStyle(.h3)
+        .foregroundStyle(fortuneScore.textGradient)
+    }
+    .padding(20)
+    .background {
+      Circle()
+        .fill(
+          LinearGradient(.fortuneFill)
+            .opacity(0.15)
+        )
+        .frame(width: 80, height: 80)
+        .overlay(
+          Circle()
+            .stroke(
+              fortuneScore.strokeGradient
+                .opacity(0.28),
+              lineWidth: 1
+            )
+        )
+    }
+  }
+}
+
+extension FortuneCoreView {
+  enum FortuneScore {
+    case top, mid, low
+
+    init(score: Int) {
+      switch score {
+      case 0...40:
+        self = .low
+      case 41...70:
+        self = .mid
+      case 71...100:
+        self = .top
+      default:
+        self = .low
+      }
+    }
+
+    var strokeGradient: LinearGradient {
+      switch self {
+      case .low:
+        return LinearGradient(.fortuneBorderLow)
+      case .mid:
+        return LinearGradient(.fortuneBorderMid)
+      case .top:
+        return LinearGradient(.fortuneBorderTop)
+      }
+    }
+
+    var textGradient: LinearGradient {
+      switch self {
+      case .low:
+        return LinearGradient(.fortuneGradientLow)
+      case .mid:
+        return LinearGradient(.fortuneGradientMid)
+      case .top:
+        return LinearGradient(.fortuneGradientTop)
+      }
+    }
+  }
+}
+
+#Preview {
+  FortuneCoreView(score: 35)
+  FortuneCoreView(score: 60)
+  FortuneCoreView(score: 100)
+}

--- a/Project/App/Sources/Design System/View/Fortune/FortuneCoreView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneCoreView.swift
@@ -9,10 +9,11 @@ import SwiftUI
 
 struct FortuneCoreView: View {
   let score: Int
+  private var fortuneScore: FortuneScore {
+    FortuneScore(score: score)
+  }
 
   var body: some View {
-    let fortuneScore = FortuneScore(score: score)
-
     VStack(spacing: 0) {
       Text("금전운")
         .textStyle(.body6)

--- a/Project/App/Sources/Design System/View/Gradient/LinearGradient.swift
+++ b/Project/App/Sources/Design System/View/Gradient/LinearGradient.swift
@@ -13,7 +13,14 @@ extension LinearGradient {
     case text01
     case text02
     case cardBorder
-    
+    case fortuneFill
+    case fortuneBorderLow
+    case fortuneBorderMid
+    case fortuneBorderTop
+    case fortuneGradientLow
+    case fortuneGradientMid
+    case fortuneGradientTop
+
     var stops: [Gradient.Stop] {
       switch self {
       case .tooltip01:
@@ -35,7 +42,46 @@ extension LinearGradient {
         return [
           .init(color: ColorResource.D_7_E_1_EE.color.opacity(0.3), location: 0),
           .init(color: ColorResource._414_BAE.color.opacity(0.3), location: 0.89),
-          .init(color: ColorResource.Neutral._500.color, location: 1.0)
+          .init(color: ColorResource.Neutral._500.color, location: 1.0),
+        ]
+
+      // MARK: Fortune Core
+      case .fortuneFill:
+        return [
+          .init(color: ColorResource.Background.glassEffect.color, location: 0),
+          .init(color: ColorResource.Text.Highlights.secondary.color, location: 1.0),
+        ]
+
+      case .fortuneBorderLow:
+        return [
+          .init(color: ColorResource.Neutral._400.color, location: 0),
+          .init(color: ColorResource.Neutral._200.color, location: 1.0),
+        ]
+      case .fortuneBorderMid:
+        return [
+          .init(color: ColorResource.Violet._400.color, location: 0),
+          .init(color: ColorResource.Neutral._200.color, location: 1.0),
+        ]
+      case .fortuneBorderTop:
+        return [
+          .init(color: ColorResource.Violet._400.color, location: 0),
+          .init(color: ColorResource.Neutral._200.color, location: 1.0),
+        ]
+
+      case .fortuneGradientLow:
+        return [
+          .init(color: ColorResource.EEEBD_8.color, location: 0.17),
+          .init(color: ColorResource._6_F_6_F_6_F.color, location: 1.0),
+        ]
+      case .fortuneGradientMid:
+        return [
+          .init(color: ColorResource.Neutral._30.color, location: 0.17),
+          .init(color: ColorResource.Violet._500.color, location: 1.0),
+        ]
+      case .fortuneGradientTop:
+        return [
+          .init(color: ColorResource.E_9_FBFF.color, location: 0.17),
+          .init(color: ColorResource._5194_FF.color, location: 1.0),
         ]
       }
     }

--- a/Project/App/Sources/Feature/Home/Component/HomeToolTipView.swift
+++ b/Project/App/Sources/Feature/Home/Component/HomeToolTipView.swift
@@ -34,6 +34,7 @@ struct HomeToolTipView: View {
       .multilineTextAlignment(.center)
       .foregroundStyle(ColorResource.Text.main.color)
       .padding(.horizontal, 2)
+      .fixedSize(horizontal: true, vertical: true)
   }
   
   private var bottomArrowView: some View {

--- a/Project/App/Sources/Feature/Home/HomeReducer.swift
+++ b/Project/App/Sources/Feature/Home/HomeReducer.swift
@@ -12,17 +12,23 @@ import ComposableArchitecture
 @Reducer
 struct HomeReducer {
   @ObservableState
-  struct State: Equatable {}
+  struct State: Equatable {
+    var missionList = MissionListReducer.State()
+  }
 
   enum Action {
-    case sampleAction
+    case missionList(MissionListReducer.Action)
   }
 
   var body: some ReducerOf<Self> {
+    Scope(state: \.missionList, action: \.missionList) {
+      MissionListReducer()
+    }
+
     Reduce { _, action in
       switch action {
-      case .sampleAction:
-        .none
+      case .missionList:
+        return .none
       }
     }
   }

--- a/Project/App/Sources/Feature/Home/HomeToolTipView.swift
+++ b/Project/App/Sources/Feature/Home/HomeToolTipView.swift
@@ -1,0 +1,51 @@
+//
+//  HomeToolTipView.swift
+//  Flifin
+//
+//  Created by 김유빈 on 6/29/25.
+//
+
+import SwiftUI
+
+struct HomeToolTipView: View {
+  private let message: String
+  
+  init(message: String) {
+    self.message = message
+  }
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      contentView
+      bottomArrowView
+    }
+  }
+  
+  private var contentView: some View {
+    textView
+      .padding(10)
+      .background(ColorResource.Neutral._500.color)
+      .clipShape(RoundedRectangle(cornerRadius: 8))
+  }
+  
+  private var textView: some View {
+    Text(message)
+      .textStyle(.body5)
+      .multilineTextAlignment(.center)
+      .foregroundStyle(ColorResource.Text.main.color)
+      .padding(.horizontal, 2)
+  }
+  
+  private var bottomArrowView: some View {
+    BottomRoundedInvertedTriangle(cornerRadius: 1)
+      .fill(ColorResource.Neutral._500.color)
+      .frame(width: 12, height: 6)
+  }
+}
+
+#Preview {
+  HomeToolTipView(
+    message: "좋은 금융 습관 형성을 위해\n2주간 매일 진행하는 미션이에요!"
+  )
+}
+

--- a/Project/App/Sources/Feature/Home/HomeView.swift
+++ b/Project/App/Sources/Feature/Home/HomeView.swift
@@ -13,6 +13,85 @@ struct HomeView: View {
   @Bindable var store: StoreOf<HomeReducer>
 
   var body: some View {
-    Text("Home")
+    ScrollView {
+      VStack(spacing: 0) {
+        headerSection
+
+        Rectangle().frame(width: 144, height: 200)
+          // TODO: card 넣기
+          .frame(maxWidth: .infinity)
+          .padding([.horizontal, .top], 20)
+          .padding(.bottom, 60)
+
+        MissionListView()
+      }
+    }
+    .radialGradientBackground(type: .backgroundGradient02)
   }
+
+  // MARK: 상단 타이틀 섹션
+  private var headerSection: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text(todayDateString)
+        .textStyle(.body3)
+        .foregroundStyle(ColorResource.Neutral._300.color)
+
+      HStack(alignment: .top, spacing: 0) {
+        VStack(alignment: .leading, spacing: 12) {
+          Text("지갑이 들뜨는 날,\n한 템포 쉬어가요.") // TODO: 타이틀 연결
+            .textStyle(.h2)
+            .foregroundStyle(ColorResource.Text.Body.primary.color)
+
+          seeMoreButton
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+        Button {
+          // TODO: '오늘의 금전운' 화면으로 이동하기
+        } label: {
+          FortuneCoreView(score: 35) // TODO: 점수 연결
+        }
+      }
+    }
+    .padding(.horizontal, 20)
+  }
+
+  private var seeMoreButton: some View {
+    Button {
+      // TODO: '오늘의 금전운' 화면으로 이동
+    } label: {
+      HStack(spacing: 4) {
+        Text("더보기")
+          .textStyle(.body6)
+
+        Image(ImageResource.Chevron.right)
+          .resizable()
+          .renderingMode(.template)
+          .frame(width: 20, height: 20)
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .foregroundStyle(ColorResource.Neutral._300.color)
+      .background {
+        RoundedRectangle(cornerRadius: .infinity)
+          .foregroundStyle(ColorResource.Neutral._700.color)
+      }
+    }
+  }
+
+  private var todayDateString: String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "ko_KR")
+    formatter.dateFormat = "M월 d일"
+    return formatter.string(from: Date())
+  }
+}
+
+#Preview {
+  HomeView(
+    store: Store(
+      initialState: .init(),
+      reducer: HomeReducer.init
+    )
+  )
 }

--- a/Project/App/Sources/Feature/Home/HomeView.swift
+++ b/Project/App/Sources/Feature/Home/HomeView.swift
@@ -23,7 +23,12 @@ struct HomeView: View {
           .padding([.horizontal, .top], 20)
           .padding(.bottom, 60)
 
-        MissionListView()
+        MissionListView(
+          store: store.scope(
+            state: \.missionList,
+            action: \.missionList
+          )
+        )
       }
     }
     .radialGradientBackground(type: .backgroundGradient02)

--- a/Project/App/Sources/Feature/Home/HomeView.swift
+++ b/Project/App/Sources/Feature/Home/HomeView.swift
@@ -51,10 +51,8 @@ struct HomeView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
 
-        Button {
+        FortuneCoreView(score: 35) { // TODO: 점수 연결
           // TODO: '오늘의 금전운' 화면으로 이동하기
-        } label: {
-          FortuneCoreView(score: 35) // TODO: 점수 연결
         }
       }
     }

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListReducer.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListReducer.swift
@@ -1,0 +1,37 @@
+//
+//  MissionListReducer.swift
+//  Flifin
+//
+//  Created by 김유빈 on 7/1/25.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct MissionListReducer {
+  init() {}
+
+  @ObservableState
+  struct State: Equatable {
+    var isTooltipVisible = false
+  }
+
+  enum Action {
+    // View Action
+    case tooltipTapped
+
+    // Internal Action
+
+    // Route Action
+  }
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .tooltipTapped:
+        state.isTooltipVisible.toggle()
+        return .none
+      }
+    }
+  }
+}

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -1,0 +1,60 @@
+//
+//  MissionListView.swift
+//  Flifin
+//
+//  Created by 김유빈 on 6/29/25.
+//
+
+import SwiftUI
+
+struct MissionListView: View {
+    var body: some View {
+      VStack(spacing: 24) {
+        pinnedMissionSection
+
+        dailyMissionSection
+      }
+      .padding(.horizontal, 20)
+    }
+  
+  private var pinnedMissionSection: some View {
+    VStack(spacing: 4) {
+      HStack(spacing: 12) {
+        HStack(spacing: 8) {
+          Text("소비습관 미션")
+            .textStyle(.h4_1)
+            .foregroundStyle(ColorResource.Text.Body.primary.color)
+
+          Button {
+            // TODO: 툴팁 띄우기
+          } label: {
+            Image(ImageResource.Icon.info)
+              .renderingMode(.template)
+              .foregroundStyle(ColorResource.Neutral._400.color)
+              .frame(width: 24, height: 24)
+          }
+        }
+
+        Text("Category") // TODO: 소비 카테고리 -> Badge 컴포넌트로 대체하기 / 카테고리 연결
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      // TODO: PinnedMissionItemView 넣기
+    }
+  }
+  
+  private var dailyMissionSection: some View {
+    VStack(spacing: 16) {
+      Text("금전운 기반 일일 미션")
+        .textStyle(.h4_1)
+        .foregroundStyle(ColorResource.Text.Body.primary.color)
+
+      // TODO: DailyMissionItemView 넣기
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+#Preview {
+    MissionListView()
+}

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -7,8 +7,10 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 struct MissionListView: View {
-  @State private var isTooltipVisible = false
+  @Bindable var store: StoreOf<MissionListReducer>
 
   var body: some View {
     VStack(spacing: 24) {
@@ -28,7 +30,7 @@ struct MissionListView: View {
             .foregroundStyle(ColorResource.Text.Body.primary.color)
 
           Button {
-            isTooltipVisible.toggle()
+            store.send(.tooltipTapped)
           } label: {
             Image(ImageResource.Icon.info)
               .renderingMode(.template)
@@ -36,7 +38,7 @@ struct MissionListView: View {
               .frame(width: 24, height: 24)
           }
           .overlay {
-            if isTooltipVisible {
+            if store.isTooltipVisible {
               HomeToolTipView(
                 message: "좋은 금융 습관 형성을 위해\n2주간 매일 진행하는 미션이에요!"
               )
@@ -66,5 +68,10 @@ struct MissionListView: View {
 }
 
 #Preview {
-  MissionListView()
+  MissionListView(
+    store: Store(
+      initialState: MissionListReducer.State(),
+      reducer: MissionListReducer.init
+    )
+  )
 }

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -13,12 +13,13 @@ struct MissionListView: View {
   @Bindable var store: StoreOf<MissionListReducer>
 
   var body: some View {
-    VStack(spacing: 24) {
+    VStack(alignment: .leading, spacing: 24) {
       pinnedMissionSection
 
       dailyMissionSection
     }
     .padding(.horizontal, 20)
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 
   private var pinnedMissionSection: some View {
@@ -49,8 +50,7 @@ struct MissionListView: View {
 
         Text("식음료") // TODO: 소비 카테고리 -> Badge 컴포넌트로 대체하기 + 카테고리 연결
       }
-      .frame(maxWidth: .infinity, alignment: .leading)
-
+      
       // TODO: PinnedMissionItemView 넣기
     }
   }
@@ -63,7 +63,6 @@ struct MissionListView: View {
 
       // TODO: DailyMissionItemView 넣기
     }
-    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }
 

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -8,15 +8,17 @@
 import SwiftUI
 
 struct MissionListView: View {
-    var body: some View {
-      VStack(spacing: 24) {
-        pinnedMissionSection
+  @State private var isTooltipVisible = false
 
-        dailyMissionSection
-      }
-      .padding(.horizontal, 20)
+  var body: some View {
+    VStack(spacing: 24) {
+      pinnedMissionSection
+
+      dailyMissionSection
     }
-  
+    .padding(.horizontal, 20)
+  }
+
   private var pinnedMissionSection: some View {
     VStack(spacing: 4) {
       HStack(spacing: 12) {
@@ -26,23 +28,31 @@ struct MissionListView: View {
             .foregroundStyle(ColorResource.Text.Body.primary.color)
 
           Button {
-            // TODO: 툴팁 띄우기
+            isTooltipVisible.toggle()
           } label: {
             Image(ImageResource.Icon.info)
               .renderingMode(.template)
               .foregroundStyle(ColorResource.Neutral._400.color)
               .frame(width: 24, height: 24)
           }
+          .overlay {
+            if isTooltipVisible {
+              HomeToolTipView(
+                message: "좋은 금융 습관 형성을 위해\n2주간 매일 진행하는 미션이에요!"
+              )
+              .offset(y: -50)
+            }
+          }
         }
 
-        Text("Category") // TODO: 소비 카테고리 -> Badge 컴포넌트로 대체하기 / 카테고리 연결
+        Text("식음료") // TODO: 소비 카테고리 -> Badge 컴포넌트로 대체하기 + 카테고리 연결
       }
       .frame(maxWidth: .infinity, alignment: .leading)
 
       // TODO: PinnedMissionItemView 넣기
     }
   }
-  
+
   private var dailyMissionSection: some View {
     VStack(spacing: 16) {
       Text("금전운 기반 일일 미션")
@@ -56,5 +66,5 @@ struct MissionListView: View {
 }
 
 #Preview {
-    MissionListView()
+  MissionListView()
 }


### PR DESCRIPTION
## 📌 배경

- 홈 화면 구성 작업했습니다.

## ✅ 수정 내역

- `FortuneCoreView` 컴포넌트 구현
  - 점수에 따라 텍스트/테두리 그라데이션 스타일 다르게 적용되도록 구성
  - 점수 구간에 따른 FortuneScore enum 도입 (low, mid, top)
  - FortuneCore에 사용되는 color asset 및 LinearGradient 정의

- 소비습관 미션, 일일 미션 리스트 뷰 구성
  - `MissionListView` 생성 및 pinned/daily mission section 분리

- 홈 화면 전용 툴팁 컴포넌트 추가
  - 인포 버튼 클릭 시 툴팁 노출 가능하도록 구성

- 홈 화면 전체 레이아웃 구성
  - 상단 타이틀 섹션, fortune 점수 섹션, 미션 섹션 분리

## 📢 리뷰 노트

- 데이터 연결, 화면 이동과 같이 추가 작업해야 하는 것들은 TODO로 남겨놨습니다!
- 기존에 있던 ToolTip 컴포넌트 활용해서 사용하려고 구조 변경을 시도했는데요 ..
  - 이니셜라이저를 두 개로 분리하고 Gradient와 Color를 받도록 구성하려고 했으나 약간 문제가 생겨서 ... 시간 이슈로 일단은 홈 화면 전용 툴팁 뷰를 따로 만들었습니다! 나중에 리팩토링 할게요 :)


## 📸 스크린샷
<!-- 
 - 이미지 추가시 아래 주석의 내용을 복사하여 표에 입력하여 사용해요.
  <img src="{{ 이미지 URL을 입력해주세요 }}" width="250" />

 - 동영상 추가시 아래 주석의 내용을 복사하여 표에 입력하여 사용해요.
  <video src="{{ 동영상 URL을 입력해주세요 }}" width="250" muted autoplay />

 | ScreenShot |
 | ---------- |
-->

<img src="https://github.com/user-attachments/assets/3da4b9cd-437a-4188-b90b-c26c255f6b4b" width="250" />
<img src="https://github.com/user-attachments/assets/4881b07c-d4b5-4f63-9fdc-d1389d9e152c" width="250" />