### PR TITLE
IOS-70 자잘한 UI 수정

### DIFF
--- a/Project/App/Sources/Feature/MainTab/MainTabView.swift
+++ b/Project/App/Sources/Feature/MainTab/MainTabView.swift
@@ -14,7 +14,7 @@ struct MainTabView: View {
 
   init(store: StoreOf<MainTabReducer>) {
     self.store = store
-    UITabBar.appearance().unselectedItemTintColor = ColorResource.Neutral._600.uiColor
+    configureTabBar()
   }
 
   var body: some View {
@@ -63,5 +63,16 @@ struct MainTabView: View {
       }
     }
     .tint(ColorResource.Neutral._200.color)
+  }
+}
+
+extension MainTabView {
+  private func configureTabBar() {
+    let appearance = UITabBarAppearance()
+    appearance.configureWithOpaqueBackground()
+    UITabBar.appearance().backgroundColor = ColorResource.Background.main.color.uiColor
+    UITabBar.appearance().unselectedItemTintColor = ColorResource.Neutral._600.uiColor
+    UITabBar.appearance().standardAppearance = appearance
+    UITabBar.appearance().scrollEdgeAppearance = appearance
   }
 }

--- a/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertView.swift
+++ b/Project/App/Sources/Feature/MyPage/AppResetAlert/AppResetAlertView.swift
@@ -30,15 +30,6 @@ struct AppResetAlertView: View {
         .frame(maxWidth: .infinity, alignment: .trailing)
 
         VStack(spacing: 16) {
-          RoundedRectangle(cornerRadius: 12)
-            .fill(ColorResource.Neutral._500.color)
-            .frame(height: 100)
-            .overlay(
-              Text("그래픽 들어갈 자리")
-                .foregroundColor(.white)
-            )
-            .padding(.horizontal, 16)
-
           VStack(spacing: 4) {
             Text("정말 앱을 초기화 하시겠어요?")
               .textStyle(.h3)


### PR DESCRIPTION
## 📌 배경
- 자잘한 UI 수정

## ✅ 수정 내역

- 마이페이지 - 앱 초기화 팝업에서 그래픽 공간 제거 (스펙아웃)
- 탭바의 appearance 지정 -> 스크롤 시 배경색 변경되는 문제 해결


## 📢 리뷰 노트

- 생략해요.

## 📸 스크린샷


 | 그래픽 제거된 팝업 |
 | ---------- |
 | <img src="https://github.com/user-attachments/assets/cc8d6f2f-94bd-4157-b46f-831062734197" width="250" /> |

| 탭바 수정 |
 | ---------- |
 | <video src="https://github.com/user-attachments/assets/01881df3-280c-413f-ab03-9893f2898e3f" width="250" muted autoplay /> | 




