### PR TITLE
[IOS-76] FortuneLoadingCompleteView 계속 뜨는 현상을 수정해요

### DIFF
--- a/Project/App/Sources/Feature/Home/HomeReducer.swift
+++ b/Project/App/Sources/Feature/Home/HomeReducer.swift
@@ -33,7 +33,7 @@ struct HomeReducer {
     var presentMissionDonePopup = false
     
     var fortuneLoadingComplete: FortuneLoadingCompleteReducer.State?
-    let isFirstLaunchOfToday: Bool
+    var isFirstLaunchOfToday: Bool
     
     init(
       homeInfo: HomeInfo,
@@ -174,6 +174,7 @@ struct HomeReducer {
       case .fortuneLoadingComplete(let action):
         switch action {
         case .delegate(.moveToHome):
+          state.isFirstLaunchOfToday.toggle()
           withAnimation(.easeInOut(duration: 0.5)) {
             state.viewState = .home
           }


### PR DESCRIPTION
## 📌 배경
- FortuneLoadingCompleteView가 한 번 뜬 이후에도 계속 뜨는 현상이 발생해요

## ✅ 수정 내역
- home으로 이동 후 onAppear에서 isFirstLaunchOfToday 체크 시 계속 true로 남아있어서 발생한 현상으로, home으로 이동 후 해당 값을 토클해서 수정했어요.

## 📢 리뷰 노트
- HomeReducer로 이동은 담에...ㅋㅋ 일단 빠른 수정~~~~ 

## 📸 스크린샷
  <img src="https://github.com/user-attachments/assets/6a773ee7-893c-4c21-94dc-7daf58a3ace8" width="250" />