### PR TITLE
IOS-88 반영되지 않던 사용자 미션 완료 여부 API 요청 문제를 해결했어요

### DIFF
--- a/Project/App/Sources/Services/DHCAPISerivce/HomeService/Mission/MissionAPI.swift
+++ b/Project/App/Sources/Services/DHCAPISerivce/HomeService/Mission/MissionAPI.swift
@@ -24,6 +24,15 @@ extension MissionAPI: RequestTarget {
   var method: HTTPMethod {
     .put
   }
+  
+  var headers: HTTPHeaders? {
+    switch self {
+    case .updateMissionStatus(_, _):
+      [
+        "Content-Type": "application/json"
+      ]
+    }
+  }
 
   var queryParameters: Alamofire.Parameters? {
     nil

--- a/Project/App/Sources/Services/DHCAPISerivce/HomeService/Mission/MissionAPI.swift
+++ b/Project/App/Sources/Services/DHCAPISerivce/HomeService/Mission/MissionAPI.swift
@@ -17,7 +17,7 @@ extension MissionAPI: RequestTarget {
   var path: String {
     switch self {
     case .updateMissionStatus(let missionID, _):
-      return "/view/users/{userID}/missions/\(missionID)"
+      return "/api/users/{userID}/missions/\(missionID)"
     }
   }
 


### PR DESCRIPTION
## 📌 배경

- 홈 화면의 미션 리스트에서 사용자가 '미션 완료 체크 버튼'을 누르면, 해당 미션을 완료 상태로 변경하는 `PUT` 요청이 서버로 전송돼요.
- 두 가지 문제로 `PUT` 요청이 실패하고 있어서, 사용자의 미션 완료 여부가 반영되고 있지 않았어요.
  - 잘못된 `URL` 경로
  - `Content-Type` header 누락

## ✅ 수정 내역

- `PUT` 요청 `URL` 경로를 올바르게 수정했어요.
- `MissionAPI` 요청 헤더에 `Content-Type` 추가했어요.

## 📢 리뷰 노트

- 이제 미션 완료 여부가 잘 반영된답니다 ~!

## 📸 스크린샷
<!-- 
 - 이미지 추가시 아래 주석의 내용을 복사하여 표에 입력하여 사용해요.
  <img src="{{ 이미지 URL을 입력해주세요 }}" width="250" />

 - 동영상 추가시 아래 주석의 내용을 복사하여 표에 입력하여 사용해요.
  <video src="{{ 동영상 URL을 입력해주세요 }}" width="250" muted autoplay />

 | ScreenShot |
 | ---------- |
 | <img src="https://example.com/image.jpg" width="250" /> |
-->

| Before | After |
| ------ | ----- |
|        |       |
