### PR TITLE
[IOS-79] 인트로 02, 03 화면 UI를 수정해요

### DIFF
--- a/Project/App/Resources/Image.xcassets/fortuneCardShadow.imageset/Contents.json
+++ b/Project/App/Resources/Image.xcassets/fortuneCardShadow.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "FortuneCard-Shadow.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Project/App/Resources/Image.xcassets/fortuneCardShadow.imageset/FortuneCard-Shadow.svg
+++ b/Project/App/Resources/Image.xcassets/fortuneCardShadow.imageset/FortuneCard-Shadow.svg
@@ -1,0 +1,10 @@
+<svg width="375" height="32" viewBox="0 0 375 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<ellipse opacity="0.4" cx="187.5" cy="16" rx="66" ry="16" fill="url(#paint0_radial_3158_4257)"/>
+<defs>
+<radialGradient id="paint0_radial_3158_4257" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(187.5 16) scale(66 16)">
+<stop stop-color="#343B8C"/>
+<stop offset="0.5" stop-color="#343B8C" stop-opacity="0.5"/>
+<stop offset="1" stop-color="#343B8C" stop-opacity="0"/>
+</radialGradient>
+</defs>
+</svg>

--- a/Project/App/Sources/Design System/View/Fortune/FortuneCard/FlippableFortuneCardView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneCard/FlippableFortuneCardView.swift
@@ -44,7 +44,7 @@ struct FlippableCard<Front: View, Back: View>: View {
           perspective: 0.5
         )
     }
-    .frame(width: 250, height: 350)
+    .frame(width: 144, height: 200)
     .gesture(
       DragGesture()
         .onChanged { value in

--- a/Project/App/Sources/Design System/View/Fortune/FortuneScoreView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneScoreView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct FortuneScoreView: View {
-  private let date: String
+  private let date: String?
   private let score: String
   private let summary: String
   private let gradientType: LinearGradient.LinearType
   
   init(
-    date: String,
+    date: String?,
     score: String,
     summary: String,
     gradientType: LinearGradient.LinearType
@@ -27,11 +27,13 @@ struct FortuneScoreView: View {
   
   var body: some View {
     VStack(spacing: 12) {
-      BadgeView(
-        text: date,
-        textColor: ColorResource.Text.Body.primary.color,
-        font: Typography.Body.body6
-      )
+      if let date {
+        BadgeView(
+          text: date,
+          textColor: ColorResource.Text.Body.primary.color,
+          font: Typography.Body.body6
+        )
+      }
       
       Text(score)
         .textStyle(.h0)

--- a/Project/App/Sources/Design System/View/Fortune/FortuneView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneView.swift
@@ -15,7 +15,6 @@ struct FortuneView: View {
   private let cardBackgroundImageURL: URL?
   private let cardTitle: String
   private let cardFortune: String
-  private let needsGradientBackground: Bool
   
   init(
     date: String,
@@ -24,8 +23,7 @@ struct FortuneView: View {
     gradientType: LinearGradient.LinearType,
     cardBackgroundImageURL: URL?,
     cardTitle: String,
-    cardFortune: String,
-    needsGradientBackground: Bool = false
+    cardFortune: String
   ) {
     self.date = date
     self.score = score
@@ -34,33 +32,29 @@ struct FortuneView: View {
     self.cardBackgroundImageURL = cardBackgroundImageURL
     self.cardTitle = cardTitle
     self.cardFortune = cardFortune
-    self.needsGradientBackground = needsGradientBackground
   }
   
   var body: some View {
-    VStack(spacing: 20) {
+    VStack(spacing: 0) {
       FortuneScoreView(
         date: date,
         score: score,
         summary: summary,
         gradientType: gradientType
       )
+      .padding(.bottom, 24)
       
       FortuneCardFrontView(
         backgroundImageURL: cardBackgroundImageURL,
         title: cardTitle,
         fortune: cardFortune
       )
-      .if(needsGradientBackground) { cardView in
-        cardView
-          .radialGradientBackground(
-            type: .backgroundGradient01,
-            endRadiusMultiplier: 0.4,
-            scaleEffectX: 2.5,
-            scaleEffectY: 1.6
-          )
-      }
-      .padding(.bottom, 20)
+      .padding(.top, 40)
+      .padding(.bottom, 12)
+      
+      ImageResource.fortuneCardShadow.image
+        .resizable()
+        .frame(height: 32)
     }
   }
 }

--- a/Project/App/Sources/Design System/View/Fortune/FortuneView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct FortuneView: View {
   private let date: String
+  private let date: String?
   private let score: String
   private let summary: String
   private let gradientType: LinearGradient.LinearType
@@ -17,7 +18,7 @@ struct FortuneView: View {
   private let cardFortune: String
   
   init(
-    date: String,
+    date: String?,
     score: String,
     summary: String,
     gradientType: LinearGradient.LinearType,

--- a/Project/App/Sources/Design System/View/Fortune/FortuneView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneView.swift
@@ -7,32 +7,25 @@
 
 import SwiftUI
 
-struct FortuneView: View {
-  private let date: String
+struct FortuneView<Card: View>: View {
   private let date: String?
   private let score: String
   private let summary: String
   private let gradientType: LinearGradient.LinearType
-  private let cardBackgroundImageURL: URL?
-  private let cardTitle: String
-  private let cardFortune: String
+  private let cardView: Card
   
   init(
     date: String?,
     score: String,
     summary: String,
     gradientType: LinearGradient.LinearType,
-    cardBackgroundImageURL: URL?,
-    cardTitle: String,
-    cardFortune: String
+    @ViewBuilder cardView: () -> Card
   ) {
     self.date = date
     self.score = score
     self.summary = summary
     self.gradientType = gradientType
-    self.cardBackgroundImageURL = cardBackgroundImageURL
-    self.cardTitle = cardTitle
-    self.cardFortune = cardFortune
+    self.cardView = cardView()
   }
   
   var body: some View {
@@ -45,11 +38,7 @@ struct FortuneView: View {
       )
       .padding(.bottom, 24)
       
-      FortuneCardFrontView(
-        backgroundImageURL: cardBackgroundImageURL,
-        title: cardTitle,
-        fortune: cardFortune
-      )
+      cardView
       .padding(.top, 40)
       .padding(.bottom, 12)
       

--- a/Project/App/Sources/Feature/Home/FortuneDetail/FortuneDetailView.swift
+++ b/Project/App/Sources/Feature/Home/FortuneDetail/FortuneDetailView.swift
@@ -37,9 +37,13 @@ struct FortuneDetailView: View {
               score: detailInfo.scoreInfo.scoreString,
               summary: detailInfo.scoreInfo.summary,
               gradientType: FortuneScore(score: detailInfo.scoreInfo.score).textGradient,
-              cardBackgroundImageURL: detailInfo.cardInfo.backgroundImageURL,
-              cardTitle: detailInfo.cardInfo.title,
-              cardFortune: detailInfo.cardInfo.fortune
+              cardView: {
+                FortuneCardFrontView(
+                  backgroundImageURL: detailInfo.cardInfo.backgroundImageURL,
+                  title: detailInfo.cardInfo.title,
+                  fortune: detailInfo.cardInfo.fortune
+                )
+              }
             )
             .padding(.top, 32)
           }

--- a/Project/App/Sources/Feature/Home/FortuneLoading/LoadingComplete/FortuneLoadingCompleteView.swift
+++ b/Project/App/Sources/Feature/Home/FortuneLoading/LoadingComplete/FortuneLoadingCompleteView.swift
@@ -25,42 +25,49 @@ struct FortuneLoadingCompleteView: View {
       }
     }
     .frame(maxWidth: .infinity)
+    .radialGradientBackground(
+      type: .backgroundGradient02,
+      endRadiusMultiplier: 1.2,
+      scaleEffectX: 1.8
+    )
     .background(ColorResource.Background.main.color)
   }
   
   var defaultView: some View {
-    VStack(spacing: 84) {
-      FortuneScoreView(
-        date: store.scoreInfo.date,
-        score: "?점",
-        summary: "운세 카드를 뒤집고\n오늘의 금전운을 확인해보세요",
-        gradientType: .text02
-      )
-      
-      FlippableCard(
-        frontContent: {
-          FortuneCardBackView(backgroundImageURL: .urlForResource(.fortuneCardBackView))
-        },
-        backContent: {
-          FortuneCardFrontView(
-            backgroundImageURL: store.cardInfo.backgroundImageURL,
-            title: store.cardInfo.title,
-            fortune: store.cardInfo.fortune
-          )
-        },
-        flipCompletion: {
-          _ = withAnimation {
-            store.send(.cardFlipped)
+    FortuneView(
+      date: store.scoreInfo.date,
+      score: "?점",
+      summary: "운세 카드를 뒤집고\n오늘의 금전운을 확인해보세요",
+      gradientType: .text02,
+      cardView: {
+        FlippableCard(
+          frontContent: {
+            FortuneCardBackView(backgroundImageURL: .urlForResource(.fortuneCardBackView))
+          },
+          backContent: {
+            FortuneCardFrontView(
+              backgroundImageURL: store.cardInfo.backgroundImageURL,
+              title: store.cardInfo.title,
+              fortune: store.cardInfo.fortune
+            )
+          },
+          flipCompletion: {
+            _ = withAnimation {
+              store.send(.cardFlipped)
+            }
           }
+        )
+        .rotationEffect(.degrees(-4))
+        .padding(.top, 20)
+        .overlay(alignment: .top) {
+          OnboardingTooltipView(message: "Flip!")
+            .padding(.trailing, 10)
+            .padding(.top, -40)
         }
-      )
-      .rotationEffect(.degrees(-4))
-      .overlay(alignment: .top) {
-        OnboardingTooltipView(message: "Flip!")
-          .padding(.trailing, 10)
       }
-    }
-    .frame(maxHeight: .infinity)
+    )
+    .frame(maxHeight: .infinity, alignment: .top)
+    .padding(.top, 64)
   }
   
   var cardFlippedView: some View {
@@ -77,6 +84,7 @@ struct FortuneLoadingCompleteView: View {
         )
       }
     )
-    .frame(maxHeight: .infinity)
+    .frame(maxHeight: .infinity, alignment: .top)
+    .padding(.top, 64)
   }
 }

--- a/Project/App/Sources/Feature/Home/FortuneLoading/LoadingComplete/FortuneLoadingCompleteView.swift
+++ b/Project/App/Sources/Feature/Home/FortuneLoading/LoadingComplete/FortuneLoadingCompleteView.swift
@@ -71,8 +71,7 @@ struct FortuneLoadingCompleteView: View {
       gradientType: FortuneScore(score: store.scoreInfo.score).textGradient,
       cardBackgroundImageURL: store.cardInfo.backgroundImageURL,
       cardTitle: store.cardInfo.title,
-      cardFortune: store.cardInfo.fortune,
-      needsGradientBackground: true
+      cardFortune: store.cardInfo.fortune
     )
     .frame(maxHeight: .infinity)
   }

--- a/Project/App/Sources/Feature/Home/FortuneLoading/LoadingComplete/FortuneLoadingCompleteView.swift
+++ b/Project/App/Sources/Feature/Home/FortuneLoading/LoadingComplete/FortuneLoadingCompleteView.swift
@@ -69,9 +69,13 @@ struct FortuneLoadingCompleteView: View {
       score: store.scoreInfo.scoreString,
       summary: store.scoreInfo.summary,
       gradientType: FortuneScore(score: store.scoreInfo.score).textGradient,
-      cardBackgroundImageURL: store.cardInfo.backgroundImageURL,
-      cardTitle: store.cardInfo.title,
-      cardFortune: store.cardInfo.fortune
+      cardView: {
+        FortuneCardFrontView(
+          backgroundImageURL: store.cardInfo.backgroundImageURL,
+          title: store.cardInfo.title,
+          fortune: store.cardInfo.fortune
+        )
+      }
     )
     .frame(maxHeight: .infinity)
   }

--- a/Project/App/Sources/Feature/MainTab/MainTabView.swift
+++ b/Project/App/Sources/Feature/MainTab/MainTabView.swift
@@ -71,7 +71,8 @@ struct MainTabView: View {
 extension MainTabView {
   private func configureTabBar() {
     let appearance = UITabBarAppearance()
-    appearance.configureWithOpaqueBackground()
+    appearance.configureWithTransparentBackground()
+    
     UITabBar.appearance().backgroundColor = ColorResource.Background.main.color.uiColor
     UITabBar.appearance().unselectedItemTintColor = ColorResource.Neutral._600.uiColor
     UITabBar.appearance().standardAppearance = appearance

--- a/Project/App/Sources/Feature/MissionStatus/ReportView.swift
+++ b/Project/App/Sources/Feature/MissionStatus/ReportView.swift
@@ -85,6 +85,7 @@ struct ReportView: View {
       endRadiusMultiplier: 1.2,
       scaleEffectX: 1.8
     )
+    .background(ColorResource.Background.main.color)
     .redacted(reason: store.isRedacted ? .placeholder : [])
   }
 }

--- a/Project/App/Sources/Feature/MyPage/MyPageView.swift
+++ b/Project/App/Sources/Feature/MyPage/MyPageView.swift
@@ -94,5 +94,6 @@ struct MyPageView: View {
     .resetAlert(
       item: $store.scope(state: \.appResetAlert, action: \.appResetAlert)
     )
+    .background(ColorResource.Background.main.color)
   }
 }

--- a/Project/App/Sources/Feature/Onboarding/Intro/FortunePickExample/FortunePickExampleView.swift
+++ b/Project/App/Sources/Feature/Onboarding/Intro/FortunePickExample/FortunePickExampleView.swift
@@ -81,9 +81,13 @@ struct FortunePickExampleView: View {
         score: "35점",
         summary: "마음이 들뜨는 날이에요,\n한템포 쉬어가요.",
         gradientType: .text02,
-        cardBackgroundImageURL: .urlForResource(.fortuneCardFrontDefaultView),
-        cardTitle: "최고의 날",
-        cardFortune: "네잎클로버"
+        cardView: {
+          FortuneCardFrontView(
+            backgroundImageURL: .urlForResource(.fortuneCardFrontDefaultView),
+            title: "최고의 날",
+            fortune: "네잎클로버"
+          )
+        }
       )
       .frame(maxHeight: .infinity)
       

--- a/Project/App/Sources/Feature/Onboarding/Intro/FortunePickExample/FortunePickExampleView.swift
+++ b/Project/App/Sources/Feature/Onboarding/Intro/FortunePickExample/FortunePickExampleView.swift
@@ -83,8 +83,7 @@ struct FortunePickExampleView: View {
         gradientType: .text02,
         cardBackgroundImageURL: .urlForResource(.fortuneCardFrontDefaultView),
         cardTitle: "최고의 날",
-        cardFortune: "네잎클로버",
-        needsGradientBackground: true
+        cardFortune: "네잎클로버"
       )
       .frame(maxHeight: .infinity)
       

--- a/Project/App/Sources/Feature/Onboarding/Intro/FortunePickExample/FortunePickExampleView.swift
+++ b/Project/App/Sources/Feature/Onboarding/Intro/FortunePickExample/FortunePickExampleView.swift
@@ -23,6 +23,7 @@ struct FortunePickExampleView: View {
         title: "먼저 금전운을 하나\n받아볼까요?"
       )
       .padding(.top, 24)
+      .padding(.bottom, 44)
       
       if store.isCardFlipped {
         cardFlippedView
@@ -36,50 +37,47 @@ struct FortunePickExampleView: View {
   }
   
   var defaultView: some View {
-    VStack(spacing: 80) {
-      Text("오늘의 운세 카드를\n뒤집어보세요!")
-        .textStyle(.h3)
-        .foregroundStyle(ColorResource.Text.Body.primary.color)
-        .multilineTextAlignment(.center)
-      
-      FlippableCard(
-        frontContent: {
-          FortuneCardBackView(backgroundImageURL: .urlForResource(.fortuneCardBackView))
-        },
-        backContent: {
-          FortuneCardFrontView(
-            backgroundImageURL: .urlForResource(.fortuneCardFrontDefaultView),
-            title: "최고의 날",
-            fortune: "네잎클로버"
-          )
-        },
-        flipCompletion: {
-          _ = withAnimation {
-            store.send(.cardFlipped)
+    FortuneView(
+      date: nil,
+      score: "?점",
+      summary: "운세 카드를 뒤집고\n오늘의 금전운을 확인해보세요",
+      gradientType: .text02,
+      cardView: {
+        FlippableCard(
+          frontContent: {
+            FortuneCardBackView(backgroundImageURL: .urlForResource(.fortuneCardBackView))
+          },
+          backContent: {
+            FortuneCardFrontView(
+              backgroundImageURL: .urlForResource(.fortuneCardFrontDefaultView),
+              title: "최고의 날",
+              fortune: "네잎클로버"
+            )
+          },
+          flipCompletion: {
+            _ = withAnimation {
+              store.send(.cardFlipped)
+            }
           }
+        )
+        .rotationEffect(.degrees(-4))
+        .padding(.top, 20)
+        .overlay(alignment: .top) {
+          OnboardingTooltipView(message: "Flip!")
+            .padding(.trailing, 10)
+            .padding(.top, -40)
         }
-      )
-      .rotationEffect(.degrees(-4))
-      .radialGradientBackground(
-        type: .backgroundGradient01,
-        endRadiusMultiplier: 0.4,
-        scaleEffectX: 2.5,
-        scaleEffectY: 1.6
-      )
-      .overlay(alignment: .top) {
-        OnboardingTooltipView(message: "Flip!")
-          .padding(.trailing, 10)
       }
-    }
-    .frame(maxHeight: .infinity)
+    )
+    .frame(maxHeight: .infinity, alignment: .top)
   }
   
   var cardFlippedView: some View {
     VStack(spacing: 0) {
       FortuneView(
-        date: "2025년 5월 20일",
-        score: "35점",
-        summary: "마음이 들뜨는 날이에요,\n한템포 쉬어가요.",
+        date: nil,
+        score: "85점",
+        summary: "오늘 도착한 금전운이에요.\n함께 확인해볼까요?",
         gradientType: .text02,
         cardView: {
           FortuneCardFrontView(
@@ -89,7 +87,8 @@ struct FortunePickExampleView: View {
           )
         }
       )
-      .frame(maxHeight: .infinity)
+      
+      Spacer()
       
       CTAButton(
         size: .extraLarge,

--- a/Project/App/Sources/Models/Home/FortuneDetail/Domain/FortuneDetail.swift
+++ b/Project/App/Sources/Models/Home/FortuneDetail/Domain/FortuneDetail.swift
@@ -38,8 +38,8 @@ extension FortuneDetail {
     .init(
       scoreInfo: .init(
         date: date,
-        scoreString: "35점",
-        score: 35,
+        scoreString: "85점",
+        score: 85,
         summary: "마음이 들뜨는 날이에요,\n한템포 쉬어가요."
       ),
       cardInfo: .init(


### PR DESCRIPTION
## 📌 배경
- 온보딩 단계의 화면 디자인이 중간에 수정되어 반영해요

## ✅ 수정 내역

- 카드에 들어가는 그라디언트 이미지를 추가해요 (ㅎㅎ..원래는 radialGradient 활용해서 적용헀었는데 잘 안돼서,, 일단 빠른 반영을 위해 이미지를 넣었어용 ,,)
- FortuneView 생성 시 view 자체를 주입받도록 수정했어요(그냥 FortuneCardFrontView가 들어갈 때가 있고 FlippableCard가 들어가야할때가 있어서 뷰를 받도록 수정했어요!)
- tabBar 색상이 뭔가 다른 것 같아서 확인해보니 opaqueBackground로 설정이 돼있어서 원하는대로 반영이 안되고 있었어요! transparentBackground로 수정했습니다~


## 📢 리뷰 노트

- 패쓰 ~~

## 📸 스크린샷
 | ScreenShot |
 | ---------- |
 |   <img src="https://github.com/user-attachments/assets/1cef465a-bd63-401e-a66e-ced0d0fbcd64" width="250" /> |

 | Before | After |
 | ---------- | ---------- |
 | <img src="https://github.com/user-attachments/assets/b6f2ef00-013c-459a-91fc-ad680fca7842" width="250" /> |  <img src="https://github.com/user-attachments/assets/c5fddae4-a0c5-47c2-9057-01f64a123809" width="250" /> |
