### PR TITLE
[IOS-91] 카드 탭 했을 때 회전 애니메이션을 추가해요

### DIFF
--- a/Project/App/Sources/Design System/View/Fortune/FortuneCard/FlippableFortuneCardView.swift
+++ b/Project/App/Sources/Design System/View/Fortune/FortuneCard/FlippableFortuneCardView.swift
@@ -45,6 +45,9 @@ struct FlippableCard<Front: View, Back: View>: View {
         )
     }
     .frame(width: 144, height: 200)
+    .onTapGesture {
+      flipCard()
+    }
     .gesture(
       DragGesture()
         .onChanged { value in
@@ -79,5 +82,17 @@ struct FlippableCard<Front: View, Back: View>: View {
     let positiveAngle = normalizedAngle >= 0 ? normalizedAngle : normalizedAngle + 360
     
     return positiveAngle >= 90 && positiveAngle <= 270
+  }
+  
+  private func flipCard() {
+    withAnimation(.linear(duration: 0.5)) {
+      rotationAngle = isFlipped ? 0 : 180
+    } completion: {
+      isFlipped.toggle()
+      
+      if isFlipped {
+        flipCompletion()
+      }
+    }
   }
 }

--- a/Project/App/Sources/Feature/Onboarding/LoopingVideoPlayer.swift
+++ b/Project/App/Sources/Feature/Onboarding/LoopingVideoPlayer.swift
@@ -26,7 +26,16 @@ struct LoopingVideoPlayer: View {
   
   var body: some View {
     VideoPlayer(player: player)
-      .onAppear { player.play() }
-      .onDisappear{ player.pause() }
+      .onAppear { 
+        player.play() 
+      }
+      .onDisappear{ 
+        player.pause() 
+      }
+      .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+        if player.timeControlStatus != .playing {
+          player.play()
+        }
+      }
   }
 }

--- a/Project/App/Sources/Feature/Onboarding/OnboardingView.swift
+++ b/Project/App/Sources/Feature/Onboarding/OnboardingView.swift
@@ -33,18 +33,14 @@ struct OnboardingView: View {
         onboardingCTAButton
       }
       .background {
-        VStack(spacing: 0) {
-          Spacer()
-          LoopingVideoPlayer(
-            videoURL: .urlForResource(.onboardingVideo)!,
-            needSoundMute: true
-          )
-          .ignoresSafeArea()
-          .allowsHitTesting(false)
-          .scaledToFill()
-        }
+        LoopingVideoPlayer(
+          videoURL: .urlForResource(.onboardingVideo)!,
+          needSoundMute: true
+        )
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+        .scaledToFill()
       }
-      .background(ColorResource._020202.color)
     } destination: { store in
       switch store.case {
       case .serviceExplanation(let store):


### PR DESCRIPTION
## 📌 배경
- 카드 탭 했을 때 회전 애니메이션을 추가해요
- 디자인 QA건!
<img width="398" height="325" alt="image" src="https://github.com/user-attachments/assets/07c60c0e-197c-4221-aea1-4ad2a2f266b9" />


## ✅ 수정 내역
- 카드를 이제 스와이프하지 않고 탭 했을 때도 회전하는 애니메이션이 추가됐어요
- onboardingVideo 교체하고 레이아웃도 조금 수정했습니다!
- VideoPlayer가 백그라운드 갔다가 포그라운드로 돌아오는 경우 멈추는 현상이 있어서 그런 상황에도 재생되도록 수정했어요


## 📢 리뷰 노트

- 리뷰에 도움이 되는 내용

## 📸 스크린샷
| ScreenShot | 설명 |
| ---------- | ---------- |
| <img src="https://github.com/user-attachments/assets/6c414fc2-3a23-4f65-80f7-1da6b15cf2ee" width="250" /> | Asset 교체 및 백그라운드에서 돌아왔을 때도 재생 유지 |
| <img src="https://github.com/user-attachments/assets/2804cdd5-4613-45dc-9f1f-9e31e9919b03" width="250" /> | 탭 제스처 애니메이션 구현 
