### PR TITLE
[IOS-92] HomeView UI 수정사항을 반영해요

### DIFF
--- a/Project/App/Sources/Design System/View/Badge/DHCBadge.swift
+++ b/Project/App/Sources/Design System/View/Badge/DHCBadge.swift
@@ -70,7 +70,7 @@ extension DHCBadge {
       case .easy:
         return "Easy"
       case .medium:
-        return "Medium"
+        return "Mid"
       case .hard:
         return "Hard"
       }

--- a/Project/App/Sources/Design System/View/Mission/MissionItem.swift
+++ b/Project/App/Sources/Design System/View/Mission/MissionItem.swift
@@ -33,14 +33,13 @@ struct MissionItem<V>: View where V: View {
           CheckMark(
             size: .medium, 
             style: isMissionCompleted ? .active : .enabled)
-          .padding(20)
         }
       }
-      .padding(.horizontal, 16)
-      .background(ColorResource.Neutral._700.color)
-      .clipShape(RoundedRectangle(cornerRadius: 12))
       .frame(maxWidth: .infinity)
       .padding(.horizontal, 16)
+      .padding(.vertical, 20)
+      .background(ColorResource.Neutral._700.color)
+      .clipShape(RoundedRectangle(cornerRadius: 12))
 
       if isPinned {
         pinView()

--- a/Project/App/Sources/Design System/View/Mission/MissionItem.swift
+++ b/Project/App/Sources/Design System/View/Mission/MissionItem.swift
@@ -15,32 +15,31 @@ struct MissionItem<V>: View where V: View {
   @ViewBuilder var badgeView: () -> V
 
   var body: some View {
-    ZStack(alignment: .topLeading) {
-      HStack(spacing: 16) {
-        HStack(alignment: .top, spacing: 12) {
-          badgeView()
+    HStack(spacing: 16) {
+      HStack(alignment: .top, spacing: 12) {
+        badgeView()
 
-          Text(missionTitle)
-            .textStyle(.body3)
-            .foregroundStyle(ColorResource.Text.Body.primary.color)
-            .multilineTextAlignment(.leading)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-
-        Button {
-          isMissionCompleted.toggle()
-        } label: {
-          CheckMark(
-            size: .medium, 
-            style: isMissionCompleted ? .active : .enabled)
-        }
+        Text(missionTitle)
+          .textStyle(.body3)
+          .foregroundStyle(ColorResource.Text.Body.primary.color)
+          .multilineTextAlignment(.leading)
+          .frame(maxWidth: .infinity, alignment: .leading)
       }
-      .frame(maxWidth: .infinity)
-      .padding(.horizontal, 16)
-      .padding(.vertical, 20)
-      .background(ColorResource.Neutral._700.color)
-      .clipShape(RoundedRectangle(cornerRadius: 12))
 
+      Button {
+        isMissionCompleted.toggle()
+      } label: {
+        CheckMark(
+          size: .medium,
+          style: isMissionCompleted ? .active : .enabled)
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal, 16)
+    .padding(.vertical, 20)
+    .background(ColorResource.Neutral._700.color)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+    .overlay(alignment: .topLeading) {
       if isPinned {
         pinView()
       }
@@ -48,18 +47,11 @@ struct MissionItem<V>: View where V: View {
   }
 
   private func pinView() -> some View {
-    HStack(spacing: 0) {
-      Image(ImageResource.Icon.pin)
-        .resizable()
-        .frame(width: 24, height: 24)
-
-      Spacer()
-        .frame(maxWidth: .infinity)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.horizontal, 8)
-    .padding(.top, -12)
-    .padding(.trailing, -8)
+    Image(ImageResource.Icon.pin)
+      .resizable()
+      .frame(width: 24, height: 24)
+      .padding(.horizontal, -12)
+      .padding(.top, -12)
   }
 }
 

--- a/Project/App/Sources/Feature/Home/HomeReducer.swift
+++ b/Project/App/Sources/Feature/Home/HomeReducer.swift
@@ -35,6 +35,10 @@ struct HomeReducer {
     var fortuneLoadingComplete: FortuneLoadingCompleteReducer.State?
     var isFirstLaunchOfToday: Bool
     
+    var bottomContentMargin: CGFloat {
+      homeInfo.isTodayMissionDone ? 10 : 82
+    }
+    
     init(
       homeInfo: HomeInfo,
       fortuneLoadingComplete: FortuneLoadingCompleteReducer.State? = nil,

--- a/Project/App/Sources/Feature/Home/HomeView.swift
+++ b/Project/App/Sources/Feature/Home/HomeView.swift
@@ -74,6 +74,7 @@ struct HomeView: View {
           )
         }
       }
+      .scrollIndicators(.hidden)
 
       if !store.homeInfo.isTodayMissionDone {
         FloatingButton(title: "오늘 미션 끝내기") {

--- a/Project/App/Sources/Feature/Home/HomeView.swift
+++ b/Project/App/Sources/Feature/Home/HomeView.swift
@@ -53,18 +53,15 @@ struct HomeView: View {
             title: "최고의 날",
             fortune: "네잎클로버"
           )
-          .radialGradientBackground(
-            type: .backgroundGradient01,
-            endRadiusMultiplier: 0.4,
-            scaleEffectX: 2.5,
-            scaleEffectY: 1.6
-          )
           .rotationEffect(.init(degrees: 4))
-          .padding([.horizontal, .top], 20)
-          .padding(.bottom, 60)
+          .padding(.top, 20)
+          .padding(.bottom, 12)
           .onTapGesture {
             store.send(.moveToFortuneDetail)
           }
+          
+          ImageResource.fortuneCardShadow.image
+            .padding(.bottom, 12)
 
           MissionListView(
             store: store.scope(

--- a/Project/App/Sources/Feature/Home/HomeView.swift
+++ b/Project/App/Sources/Feature/Home/HomeView.swift
@@ -75,6 +75,7 @@ struct HomeView: View {
         }
       }
       .scrollIndicators(.hidden)
+      .contentMargins(.bottom, store.bottomContentMargin)
 
       if !store.homeInfo.isTodayMissionDone {
         FloatingButton(title: "오늘 미션 끝내기") {

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -23,7 +23,7 @@ struct MissionListView: View {
   }
 
   private var pinnedMissionSection: some View {
-    VStack(alignment: .leading, spacing: 4) {
+    VStack(alignment: .leading, spacing: 16) {
       HStack(spacing: 12) {
         HStack(spacing: 8) {
           Text("소비습관 미션")

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -16,7 +16,6 @@ struct MissionListView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 24) {
       pinnedMissionSection
-
       dailyMissionSection
     }
     .frame(maxWidth: .infinity, alignment: .leading)
@@ -53,7 +52,6 @@ struct MissionListView: View {
           badgeStyle: .spendCategory
         )
       }
-      .padding(.horizontal, 20)
 
       PinnedMissionItemView(
         missionTitle: store.longTermMission.title,
@@ -66,6 +64,7 @@ struct MissionListView: View {
         )
       )
     }
+    .padding(.horizontal, 20)
   }
 
   private var dailyMissionSection: some View {
@@ -74,7 +73,6 @@ struct MissionListView: View {
         .textStyle(.h4_1)
         .foregroundStyle(ColorResource.Text.Body.primary.color)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal,20)
 
       ForEach(store.todayDailyMissionList, id: \.id) { mission in
         DailyMissionItemView(
@@ -87,6 +85,7 @@ struct MissionListView: View {
         )
       }
     }
+    .padding(.horizontal, 20)
   }
 
   private func remainingDays(until dateString: String) -> Int {


### PR DESCRIPTION
## 📌 배경
- HomeView UI 수정사항을 반영해요

## ✅ 수정 내역

- 스크린샷 영역 참고부탁드림다,,


## 📢 리뷰 노트

- 🫠

## 📸 스크린샷
<img width="250" alt="image" src="https://github.com/user-attachments/assets/15fd052f-f711-4963-9bb8-0cde91930a71" />

- 소비습관 미션 타이틀 하단 패딩 조정
- Mission 컴포넌트 체크 버튼 패딩 수정
- 소비습관 미션 핀 위치 수정
- HomeView Card gradient 수정

<img width="250" alt="image" src="https://github.com/user-attachments/assets/8b51d011-e2ab-4033-a1ca-a043c84cbcab" />

- 미션 난이도 뱃지 'Mid'로 변경
- HomeScrollView contentMargin 수정