### PR TITLE
IOS-99 리포트 뷰 데이터 채우기 및 코드 개선

### DIFF
--- a/Project/App/Sources/Feature/Report/Components/CalendarCardView.swift
+++ b/Project/App/Sources/Feature/Report/Components/CalendarCardView.swift
@@ -91,6 +91,9 @@ struct CalendarCardView: View {
     .onChange(of: displayedMonth) { _, _ in
       calendarCells = calculateCalendarCells()
     }
+    .onChange(of: dateModels) { _, _ in
+      calendarCells = calculateCalendarCells()
+    }
   }
 
   // MARK: - Calendar Header

--- a/Project/App/Sources/Feature/Report/Components/SpendChartView.swift
+++ b/Project/App/Sources/Feature/Report/Components/SpendChartView.swift
@@ -22,7 +22,7 @@ struct SpendChartData: Identifiable, Equatable {
 
 struct SpendChartView: View {
   private let data: [SpendChartData]
-  private let maxAmount = 120000
+  private let maxAmount: Double = 120000
 
   init(data: [SpendChartData]) {
     self.data = data
@@ -32,7 +32,7 @@ struct SpendChartView: View {
     Chart(data) { item in
       BarMark(
         x: .value("Category", item.category),
-        y: .value("Amount", item.amount),
+        y: .value("Amount", min(item.amount, maxAmount)),
         width: .fixed(48)
       )
       .foregroundStyle(

--- a/Project/App/Sources/Feature/Report/ReportReducer.swift
+++ b/Project/App/Sources/Feature/Report/ReportReducer.swift
@@ -162,7 +162,7 @@ struct ReportReducer {
     let chartData: [SpendChartData] = [
       SpendChartData(
         category: "내 소비",
-        amount: reportInfo.weeklySavedMoney,
+        amount: reportInfo.weeklySpendMoney,
         isHighlighted: true
       ),
       SpendChartData(
@@ -190,7 +190,7 @@ struct ReportReducer {
       " \(reportInfo.generationComparison.generation) \(reportInfo.generationComparison.gender.title) 대비\n"
     )
 
-    let spendDifference = reportInfo.generationComparison.averageSpendMoney - reportInfo.monthlySpendMoney
+    let spendDifference = reportInfo.generationComparison.averageSpendMoney - reportInfo.weeklySpendMoney
     let amountText = AttributedString("\(abs(spendDifference).formatted(.number))원 ")
 
     var savedText = AttributedString(spendDifference >= 0 ? "더 절약했어요" : "더 낭비했어요")

--- a/Project/App/Sources/Feature/Report/ReportReducer.swift
+++ b/Project/App/Sources/Feature/Report/ReportReducer.swift
@@ -53,11 +53,13 @@ struct ReportReducer {
         }
       }
 
-    Reduce { state, action in
+    Reduce {
+      state,
+      action in
       switch action {
       case .binding:
         return .none
-
+        
       case .onAppear:
         state.isLoading = true
         state.isRedacted = true
@@ -70,7 +72,7 @@ struct ReportReducer {
             await send(.fetchMissionHistoryCalendar(currentCalendarMonth))
           },
         ])
-
+        
       case .fetchReportData:
         return .run { send in
           do {
@@ -80,12 +82,16 @@ struct ReportReducer {
             await send(.reportDataFailed(error))
           }
         }
-
+        
       case .fetchMissionHistoryCalendar(let date):
         return .run { send in
           do {
             let currentYearMonth = getCurrentCalendarYearMonth(from: date)
-            let missionHistory = try await reportClient.fetchMissionHistoryCalendar(currentYearMonth)
+            let usesCache = !Calendar.current.isDate(date, inSameDayAs: .now)
+            let missionHistory = try await reportClient.fetchMissionHistoryCalendar(
+              currentYearMonth,
+              usesCache
+            )
             await send(.missionHistoryCalendarResponse(missionHistory))
           } catch {
             await send(.missionHistoryCalendarFailed(error))

--- a/Project/App/Sources/Feature/Report/ReportView.swift
+++ b/Project/App/Sources/Feature/Report/ReportView.swift
@@ -88,5 +88,14 @@ struct ReportView: View {
     )
     .background(ColorResource.Background.main.color)
     .redacted(reason: store.isRedacted ? .placeholder : [])
+    .onShake {
+      store.send(.onShake)
+    }
+    .sensoryFeedback(
+      .impact(
+        weight: .heavy
+      ),
+      trigger: store.hapticTrigger
+    )
   }
 }

--- a/Project/App/Sources/Feature/Report/ReportView.swift
+++ b/Project/App/Sources/Feature/Report/ReportView.swift
@@ -87,7 +87,7 @@ struct ReportView: View {
       scaleEffectX: 1.8
     )
     .background(ColorResource.Background.main.color)
-    .redacted(reason: store.isRedacted ? .placeholder : [])
+    .redacted(reason: store.isLoading ? .placeholder : [])
     .onShake {
       store.send(.onShake)
     }

--- a/Project/App/Sources/Models/Report/ReportInfo.swift
+++ b/Project/App/Sources/Models/Report/ReportInfo.swift
@@ -9,8 +9,7 @@ import Foundation
 
 struct ReportInfo: Equatable {
   let totalSavedMoney: Double
-  let weeklySavedMoney: Double
-  let monthlySpendMoney: Double
+  let weeklySpendMoney: Double
   let generationComparison: GenerationComparison
 }
 
@@ -39,8 +38,7 @@ extension ReportInfo {
 extension ReportInfo {
   static let sample = ReportInfo(
     totalSavedMoney: 130000,
-    weeklySavedMoney: 28000,
-    monthlySpendMoney: 45600.00,
+    weeklySpendMoney: 28000,
     generationComparison: GenerationComparison(
       generation: "20대",
       gender: .male,

--- a/Project/App/Sources/Services/ReportService/DTO/ReportDTO.swift
+++ b/Project/App/Sources/Services/ReportService/DTO/ReportDTO.swift
@@ -9,8 +9,7 @@ import Foundation
 
 struct ReportDTO: Decodable {
   let totalSavedMoney: String
-  let weeklySavedMoney: String
-  let monthlySpendMoney: String
+  let weeklySpendMoney: String
   let generationMoneyViewResponse: GenerationMoneyViewResponse
 }
 
@@ -26,8 +25,7 @@ extension ReportDTO {
   func toDomain() -> ReportInfo {
     ReportInfo(
       totalSavedMoney: Double(totalSavedMoney) ?? 0,
-      weeklySavedMoney: Double(weeklySavedMoney) ?? 0,
-      monthlySpendMoney: Double(monthlySpendMoney) ?? 0,
+      weeklySpendMoney: Double(weeklySpendMoney) ?? 0,
       generationComparison: .init(
         generation: generationMoneyViewResponse.generation,
         gender: ReportInfo.GenerationComparison.Gender(

--- a/Project/App/Sources/Services/ReportService/ReportAPI.swift
+++ b/Project/App/Sources/Services/ReportService/ReportAPI.swift
@@ -13,6 +13,8 @@ enum ReportAPI {
   case analysis
   /// yearMonth는 "yyyy-MM" 포맷
   case calendar(yearMonth: String)
+  /// 데이터를 채우는 이스터에그
+  case addJulyHistory
 }
 
 extension ReportAPI: RequestTarget {
@@ -22,6 +24,8 @@ extension ReportAPI: RequestTarget {
       "/view/users/{userID}/analysis"
     case .calendar:
       "/view/users/{userID}/calendar"
+    case .addJulyHistory:
+      "/api/users/{userID}/add-july-history"
     }
   }
 
@@ -29,12 +33,14 @@ extension ReportAPI: RequestTarget {
     switch self {
     case .analysis, .calendar:
       .get
+    case .addJulyHistory:
+      .post
     }
   }
 
   var queryParameters: Parameters? {
     switch self {
-    case .analysis:
+    case .analysis, .addJulyHistory:
       nil
     case .calendar(let yearMonth):
       ["yearMonth": yearMonth]
@@ -43,7 +49,7 @@ extension ReportAPI: RequestTarget {
 
   var bodyParameters: (any Encodable)? {
     switch self {
-    case .analysis, .calendar:
+    case .analysis, .calendar, .addJulyHistory:
       nil
     }
   }

--- a/Project/App/Sources/Services/ReportService/ReportClient.swift
+++ b/Project/App/Sources/Services/ReportService/ReportClient.swift
@@ -13,6 +13,7 @@ import ComposableArchitecture
 struct ReportClient {
   var fetchReport: @Sendable () async throws -> ReportInfo
   var fetchMissionHistoryCalendar: @Sendable (_ yearMonth: String, _ usesCache: Bool) async throws -> MissionHistoryCalendar
+  var addJulyHistory: @Sendable () async throws -> Void
 }
 
 extension ReportClient: DependencyKey {
@@ -44,6 +45,9 @@ extension ReportClient: DependencyKey {
       }
 
       return result
+    }, addJulyHistory: {
+      _ = try await networkManager
+        .request(ReportAPI.addJulyHistory)
     })
   }()
 

--- a/Project/App/Sources/Services/ReportService/ReportClient.swift
+++ b/Project/App/Sources/Services/ReportService/ReportClient.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 @DependencyClient
 struct ReportClient {
   var fetchReport: @Sendable () async throws -> ReportInfo
-  var fetchMissionHistoryCalendar: @Sendable (_ yearMonth: String) async throws -> MissionHistoryCalendar
+  var fetchMissionHistoryCalendar: @Sendable (_ yearMonth: String, _ usesCache: Bool) async throws -> MissionHistoryCalendar
 }
 
 extension ReportClient: DependencyKey {
@@ -25,12 +25,12 @@ extension ReportClient: DependencyKey {
         .request(ReportAPI.analysis)
         .map(to: ReportDTO.self)
         .toDomain()
-    }, fetchMissionHistoryCalendar: { yearMonth in
+    }, fetchMissionHistoryCalendar: { yearMonth, usesCache in
       let cachedResult = cache.withLock {
         $0[yearMonth]
       }
 
-      if let cachedResult {
+      if usesCache, let cachedResult {
         return cachedResult
       }
 

--- a/Project/App/Sources/Util/View/DeviceShakeViewModifier.swift
+++ b/Project/App/Sources/Util/View/DeviceShakeViewModifier.swift
@@ -1,0 +1,41 @@
+//
+//  DeviceShakeViewModifier.swift
+//  Flifin
+//
+//  Created by Aiden.lee on 7/16/25.
+//
+
+import SwiftUI
+
+extension UIDevice {
+  static let deviceDidShakeNotification = Notification.Name(rawValue: "deviceDidShakeNotification")
+}
+
+///  Override the default behavior of shake gestures to send our notification instead.
+extension UIWindow {
+  open override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+    if motion == .motionShake {
+      NotificationCenter.default.post(name: UIDevice.deviceDidShakeNotification, object: nil)
+    }
+  }
+}
+
+/// A view modifier that detects shaking and calls a function of our choosing.
+struct DeviceShakeViewModifier: ViewModifier {
+  let action: () -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .onAppear()
+      .onReceive(NotificationCenter.default.publisher(for: UIDevice.deviceDidShakeNotification)) { _ in
+        action()
+      }
+  }
+}
+
+/// A View extension to make the modifier easier to use.
+extension View {
+  func onShake(perform action: @escaping () -> Void) -> some View {
+    self.modifier(DeviceShakeViewModifier(action: action))
+  }
+}


### PR DESCRIPTION
## 📌 배경
- 이스터에그로 리포트 뷰 데이터를 채워요.
- 리포트 뷰 코드 개선

## ✅ 수정 내역

- 첫 로딩 시 캘린더 뷰에 배경색이 바뀌지 않는 이슈 해결
- 데이터 채우기 이스터에그 api 추가
- 폰을 흔들면 위 api 호출
- ReportReducer 상태 관리 코드 개선
  - 공통 로직을 액션이 아닌 함수로 추출
  - concat을 활용하여 loading 상태 관리
- 차트 api 변경 대응
- 캘린더 좌우 스크롤 시 움직이는 애니메이션 추가


## 📢 리뷰 노트

- PR 쪼개야 했는데 빠르게 심사 올리기 위해 그냥 하나로 올려요..ㅎㅎ

## 📸 스크린샷

 | 캘린더 스크롤 |
 | ---------- |
 | <video src="https://github.com/user-attachments/assets/3375637b-3cb1-4681-bfdc-942538cc0076" width="250" muted autoplay /> |



