### PR TITLE
[IOS-100] 앱 사용 시 음악 꺼지는 이슈를 수정해요

### DIFF
--- a/Project/App/Sources/Feature/Onboarding/LoopingVideoPlayer.swift
+++ b/Project/App/Sources/Feature/Onboarding/LoopingVideoPlayer.swift
@@ -22,6 +22,11 @@ struct LoopingVideoPlayer: View {
     self.player = AVQueuePlayer(playerItem: item)
     self.player.isMuted = needSoundMute
     self.playerLooper = AVPlayerLooper(player: player, templateItem: item)
+    try? AVAudioSession.sharedInstance().setCategory(
+      AVAudioSession.Category.playback,
+      mode: .default,
+      options: .mixWithOthers
+    )
   }
   
   var body: some View {


### PR DESCRIPTION
## 📌 배경
- 앱 처음 사용시 온보딩 화면에 나오는 비디오 때문에 앱을 사용할 때 지속적으로 기존에 재생중이던 음악이 꺼지는 매우 화나는 상황이 발생했습니다..

## ✅ 수정 내역

- 비디오 플레이 시 다른 audio session과 mix되도록 구현했어요


## 📢 리뷰 노트

- 이제 노래 안꺼지니까 화내지마세요...

