### PR TITLE
[IOS-98] 온보딩 미션 확인 화면에서 스와이프 되지 않도록 수정해요

### DIFF
--- a/Project/App/Sources/Feature/Home/MissionList/MissionListReducer.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListReducer.swift
@@ -19,15 +19,18 @@ struct MissionListReducer {
     var longTermMission: HomeInfo.Mission
     var todayDailyMissionList: [HomeInfo.Mission] = []
     var isTodayMissionDone: Bool
+    let isSwipeEnabled: Bool
 
     init(
       longTermMission: HomeInfo.Mission,
       todayDailyMissionList: [HomeInfo.Mission],
-      isTodayMissionDone: Bool
+      isTodayMissionDone: Bool,
+      isSwipeEnabled: Bool = true
     ) {
       self.longTermMission = longTermMission
       self.todayDailyMissionList = todayDailyMissionList
       self.isTodayMissionDone = isTodayMissionDone
+      self.isSwipeEnabled = isSwipeEnabled
     }
   }
 

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -88,7 +88,7 @@ struct MissionListView: View {
               set: { _ in store.send(.dailyMissionTapped(missionID: mission.id)) }
             )
           )
-          .if(!store.isTodayMissionDone) {
+          .if(!store.isTodayMissionDone && store.isSwipeEnabled) {
             $0.swipeActions(edge: .leading) {
               Button {
                 store.send(.switchMissionButtonTapped(missionID: mission.id))

--- a/Project/App/Sources/Feature/Onboarding/Intro/MissionExample/MissionExampleReducer.swift
+++ b/Project/App/Sources/Feature/Onboarding/Intro/MissionExample/MissionExampleReducer.swift
@@ -26,7 +26,8 @@ struct MissionExampleReducer {
       self.missionList = .init(
         longTermMission: longTermMission,
         todayDailyMissionList: HomeInfo.Mission.onboardingDailyMissionList,
-        isTodayMissionDone: false
+        isTodayMissionDone: false,
+        isSwipeEnabled: false
       )
     }
   }

--- a/Project/App/Sources/Feature/Onboarding/Intro/MissionExample/MissionExampleView.swift
+++ b/Project/App/Sources/Feature/Onboarding/Intro/MissionExample/MissionExampleView.swift
@@ -28,7 +28,12 @@ struct MissionExampleView: View {
       .padding(.bottom, 45)
       
       ScrollView {
-        MissionListView(store: Store(initialState: store.missionList, reducer: EmptyReducer.init))
+        MissionListView(
+          store: Store(
+            initialState: store.missionList,
+            reducer: EmptyReducer.init
+          )
+        )
       }
       .padding(.bottom, bottomVStackHeight)
       .scrollIndicators(.hidden)


### PR DESCRIPTION
## 📌 배경
- 온보딩 화면 중 미션 샘플 보여주는 화면에서 스와이프가 되는 현상을 발견해버리다.. 수정했습니다

## ✅ 수정 내역

- MissionListReducer의 State에 스와이프 여부 파라미터를 추가해서 수정했어요~


## 📢 리뷰 노트

- 💤

