### PR TITLE
[IOS-104] HomeView의 swipe UI를 개선해요

### DIFF
--- a/Project/App/Sources/Feature/Home/FortuneDetail/FortuneDetailView.swift
+++ b/Project/App/Sources/Feature/Home/FortuneDetail/FortuneDetailView.swift
@@ -54,6 +54,7 @@ struct FortuneDetailView: View {
             .padding(.bottom, store.type == .intro ? bottomVStackHeight : 53)
         }
       }
+      .clipShape(Rectangle())
       .scrollIndicators(.hidden)
       .if(store.type == .intro) { view in
         view

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListReducer.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListReducer.swift
@@ -19,15 +19,18 @@ struct MissionListReducer {
     var longTermMission: HomeInfo.Mission
     var todayDailyMissionList: [HomeInfo.Mission] = []
     var isTodayMissionDone: Bool
+    let isSwipeEnabled: Bool
 
     init(
       longTermMission: HomeInfo.Mission,
       todayDailyMissionList: [HomeInfo.Mission],
-      isTodayMissionDone: Bool
+      isTodayMissionDone: Bool,
+      isSwipeEnabled: Bool = true
     ) {
       self.longTermMission = longTermMission
       self.todayDailyMissionList = todayDailyMissionList
       self.isTodayMissionDone = isTodayMissionDone
+      self.isSwipeEnabled = isSwipeEnabled
     }
   }
 

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -53,13 +53,17 @@ struct MissionListView: View {
           isActive: true
         )
       }
-
-      PinnedMissionItemView(
+      
+      SwipeableMissionItemView(
         missionTitle: store.longTermMission.title,
-        remainingDays: remainingDays(
-          until: store.longTermMission.endDate
-        ),
+        isPinned: true,
         isActive: !store.isTodayMissionDone,
+        isSwipeEnabled: !store.isTodayMissionDone && store.isSwipeEnabled,
+        badgeTitle: remainigDayTitle(day: remainingDays(until: store.longTermMission.endDate)),
+        badgeStyle: .spendCategory,
+        onSwitchMission: {
+          store.send(.switchMissionButtonTapped(missionID: store.longTermMission.id))
+        },
         isMissionCompleted: Binding(
           get: { store.longTermMission.isFinished },
           set: { _ in store.send(.longTermMissionTapped) }
@@ -86,9 +90,6 @@ struct MissionListView: View {
             isSwipeEnabled: !store.isTodayMissionDone && store.isSwipeEnabled,
             badgeTitle: missionLevel(for: mission.difficulty).displayName,
             badgeStyle: .missionLevel(missionLevel(for: mission.difficulty)),
-            onMissionTap: {
-              store.send(.dailyMissionTapped(missionID: mission.id))
-            },
             onSwitchMission: {
               store.send(.switchMissionButtonTapped(missionID: mission.id))
             },
@@ -116,6 +117,10 @@ struct MissionListView: View {
     let end = calendar.startOfDay(for: endDate)
 
     return max(calendar.dateComponents([.day], from: today, to: end).day ?? 0, 0)
+  }
+  
+  private func remainigDayTitle(day: Int) -> String {
+    day == 0 ? "D-day" : "D-\(day)"
   }
 
   private func missionLevel(for difficulty: Int) -> DHCBadge.MissionLevel {

--- a/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/MissionListView.swift
@@ -77,37 +77,30 @@ struct MissionListView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 20)
 
-      List {
+      VStack(spacing: 8) {
         ForEach(store.todayDailyMissionList, id: \.id) { mission in
-          DailyMissionItemView(
+          SwipeableMissionItemView(
             missionTitle: mission.title,
-            missionLevel: missionLevel(for: mission.difficulty),
+            isPinned: false,
             isActive: !store.isTodayMissionDone,
+            isSwipeEnabled: !store.isTodayMissionDone && store.isSwipeEnabled,
+            badgeTitle: missionLevel(for: mission.difficulty).displayName,
+            badgeStyle: .missionLevel(missionLevel(for: mission.difficulty)),
+            onMissionTap: {
+              store.send(.dailyMissionTapped(missionID: mission.id))
+            },
+            onSwitchMission: {
+              store.send(.switchMissionButtonTapped(missionID: mission.id))
+            },
             isMissionCompleted: Binding(
               get: { mission.isFinished },
               set: { _ in store.send(.dailyMissionTapped(missionID: mission.id)) }
             )
           )
-          .if(!store.isTodayMissionDone) {
-            $0.swipeActions(edge: .leading) {
-              Button {
-                store.send(.switchMissionButtonTapped(missionID: mission.id))
-              } label: {
-                ImageResource.Icon.update.image
-                  .frame(width: 20, height: 20)
-
-                Text("미션 바꾸기")
-              }
-              .tint(ColorResource.Violet._400.color)
-            }
-          }
-          .plainListRow()
         }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 20)
       }
-      .plainListBackground()
-      .frame(minHeight: 300)
+      .padding(.horizontal, 20)
+      .padding(.vertical, 8)
     }
   }
 

--- a/Project/App/Sources/Feature/Home/MissionList/SwipeableMissionItemView.swift
+++ b/Project/App/Sources/Feature/Home/MissionList/SwipeableMissionItemView.swift
@@ -1,0 +1,124 @@
+//
+//  SwipeableMissionItemView.swift
+//  Flifin
+//
+//  Created by 최혜린 on 7/17/25.
+//
+
+import SwiftUI
+
+struct SwipeableMissionItemView: View {
+  let missionTitle: String
+  let isPinned: Bool
+  let isActive: Bool
+  let isSwipeEnabled: Bool
+  let badgeTitle: String
+  let badgeStyle: DHCBadge.BadgeStyle
+  let onSwitchMission: () -> Void
+  
+  @Binding var isMissionCompleted: Bool
+  @State private var dragOffset: CGFloat = 0
+  @State private var isShowingAction = false
+  
+  private let actionButtonWidth: CGFloat = 137
+  private let hapticFeedback = UIImpactFeedbackGenerator(style: .medium)
+  
+  var body: some View {
+    ZStack {
+      actionButton
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(isShowingAction ? 1 : 0)
+      
+      MissionItem(
+        missionTitle: missionTitle,
+        isPinned: isPinned,
+        isActive: isActive,
+        isMissionCompleted: $isMissionCompleted
+      ) {
+        DHCBadge(
+          badgeTitle: badgeTitle,
+          badgeStyle: badgeStyle,
+          isActive: isActive
+        )
+      }
+      .offset(x: dragOffset)
+      .if(isSwipeEnabled) {
+        $0.gesture(
+          DragGesture()
+            .onChanged { value in
+              handleDragChanged(value)
+            }
+            .onEnded { value in
+              handleDragEnded(value)
+            }
+        )
+      }
+    }
+    .animation(.spring(response: 0.4, dampingFraction: 0.8), value: dragOffset)
+    .animation(.spring(response: 0.3, dampingFraction: 0.9), value: isShowingAction)
+  }
+  
+  private var actionButton: some View {
+    Button {
+      withAnimation(
+        .spring(response: 0.3, dampingFraction: 0.9)
+      ) {
+        dragOffset = 0
+        isShowingAction = false
+      }
+      onSwitchMission()
+    } label: {
+      VStack(spacing: 4) {
+        ImageResource.Icon.update.image
+          .resizable()
+          .frame(width: 20, height: 20)
+        
+        Text("미션 바꾸기")
+          .textStyle(.body3)
+          .foregroundStyle(ColorResource.Text.main.color)
+      }
+      .frame(maxHeight: .infinity)
+      .padding(.trailing, 20)
+      .frame(width: actionButtonWidth)
+      .background(ColorResource.Violet._400.color)
+    }
+    .padding(.leading, -20)
+  }
+  
+  private func handleDragChanged(_ value: DragGesture.Value) {
+    guard isActive else { return }
+    
+    let translation = value.translation.width
+    
+    // 우측으로만 드래그 허용 (양수 값만)
+    if translation > 0 {
+      dragOffset = min(translation, actionButtonWidth)
+      
+      // 임계점 도달 시 햅틱 피드백
+      if !isShowingAction && dragOffset > actionButtonWidth * 0.3 {
+        isShowingAction = true
+        hapticFeedback.impactOccurred()
+      } else if isShowingAction && dragOffset <= actionButtonWidth * 0.3 {
+        isShowingAction = false
+      }
+    }
+  }
+  
+  private func handleDragEnded(_ value: DragGesture.Value) {
+    guard isActive else { return }
+    
+    let translation = value.translation.width
+    let velocity = value.velocity.width
+    
+    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+      // 속도가 빠르거나 충분히 드래그한 경우 액션 버튼 표시
+      if velocity > 500 || translation > actionButtonWidth * 0.5 {
+        dragOffset = actionButtonWidth - 40
+        isShowingAction = true
+      } else {
+        dragOffset = 0
+        isShowingAction = false
+      }
+    }
+  }
+}

--- a/Project/App/Sources/Feature/Onboarding/Intro/MissionExample/MissionExampleReducer.swift
+++ b/Project/App/Sources/Feature/Onboarding/Intro/MissionExample/MissionExampleReducer.swift
@@ -26,7 +26,8 @@ struct MissionExampleReducer {
       self.missionList = .init(
         longTermMission: longTermMission,
         todayDailyMissionList: HomeInfo.Mission.onboardingDailyMissionList,
-        isTodayMissionDone: false
+        isTodayMissionDone: false,
+        isSwipeEnabled: false
       )
     }
   }


### PR DESCRIPTION
## 📌 배경
- 클로드와 함께 열심히 Home의 스와이프 UI를 개선했어요..^_^

## ✅ 수정 내역

- Swipe 가능한 MissionItem을 구현하고 LongTermMission, DailyMission 모두 적용했어요


## 📢 리뷰 노트

- MissionListView 내부에 데이터를 가공하는 로직이 있는 부분이 조금 아쉬운데 추후 섹션별 Model을 두고 사용하면 이 부분은 개선할 수 있을 것 같아요~


## 📸 스크린샷
  <video src="https://github.com/user-attachments/assets/7e94c5f4-bbc3-44db-ab0b-1f4de754280a" width="250" muted autoplay />